### PR TITLE
Remove Extra Current Cycle List Logs

### DIFF
--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -71,9 +71,10 @@ type Client struct {
 	accAddr   sdk.AccAddress
 	minGasFee string
 	// logger is the logger for the daemon.
-	logger     log.Logger
-	txChan     chan TxChannelInfo
-	PriceGuard *PriceGuard
+	logger                 log.Logger
+	txChan                 chan TxChannelInfo
+	PriceGuard             *PriceGuard
+	lastLoggedCycleQueryID string
 }
 
 // GetUniqueUnorderedTimeout generates a unique timeout timestamp for unordered transactions.

--- a/reporter/client/current_query.go
+++ b/reporter/client/current_query.go
@@ -19,6 +19,10 @@ func (c *Client) CurrentQuery(ctx context.Context) ([]byte, *oracletypes.QueryMe
 		return nil, nil, fmt.Errorf("error parsing query id from response: %w", err)
 	}
 
-	c.logger.Info("ReporterDaemon", "current query id in cycle list", hex.EncodeToString(utils.QueryIDFromData(querydata)))
+	queryID := hex.EncodeToString(utils.QueryIDFromData(querydata))
+	if queryID != c.lastLoggedCycleQueryID {
+		c.logger.Info("ReporterDaemon", "current query id in cycle list", queryID)
+		c.lastLoggedCycleQueryID = queryID
+	}
 	return querydata, response.QueryMeta, nil
 }


### PR DESCRIPTION
Currently, when the cycle list changes we get 6 or more duplicate logs that say "current query id in cycle list". This change just checks if that log exists already and prevents extras to make the logs more readable.