### PR TITLE
relocate cycle list log

### DIFF
--- a/reporter/client/current_query.go
+++ b/reporter/client/current_query.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 
 	"github.com/tellor-io/layer/utils"
@@ -19,6 +18,5 @@ func (c *Client) CurrentQuery(ctx context.Context) ([]byte, *oracletypes.QueryMe
 		return nil, nil, fmt.Errorf("error parsing query id from response: %w", err)
 	}
 
-	c.logger.Info("ReporterDaemon", "current query id in cycle list", hex.EncodeToString(utils.QueryIDFromData(querydata)))
 	return querydata, response.QueryMeta, nil
 }

--- a/reporter/client/reporter_monitors.go
+++ b/reporter/client/reporter_monitors.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"runtime"
@@ -15,6 +16,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 	"github.com/spf13/viper"
 	tokenbridgetipstypes "github.com/tellor-io/layer-daemons/server/types/token_bridge_tips"
+	"github.com/tellor-io/layer/utils"
 	oracletypes "github.com/tellor-io/layer/x/oracle/types"
 	reportertypes "github.com/tellor-io/layer/x/reporter/types"
 
@@ -58,6 +60,8 @@ func (c *Client) MonitorCyclelistQuery(ctx context.Context, wg *sync.WaitGroup) 
 			if bytes.Equal(querydata, prevQueryData) || hasCommited {
 				continue
 			}
+
+			c.logger.Info("ReporterDaemon", "current query id in cycle list", hex.EncodeToString(utils.QueryIDFromData(querydata)))
 
 			// Handle report generation with timeout
 			txCtx, cancel := context.WithTimeout(ctx, defaultTxTimeout)


### PR DESCRIPTION
Currently there are many duplicate log entries about the cycle list query Id. This PR removes the log from current_query.go to reporter_monitors.go where it will only get triggered once per cycle list query-id change.