### PR TITLE
fix: invalidate cached gas estimate on out-of-gas failures

### DIFF
--- a/reporter/client/tx_handler.go
+++ b/reporter/client/tx_handler.go
@@ -27,11 +27,23 @@ var (
 	BRIDGE_REPORT_TYPE = reflect.TypeOf("bridge_deposit_report")
 )
 
+// invalidateGasEstimate removes the cached gas estimate for the given message
+// type, forcing the next transaction to re-simulate gas against current chain
+// state. This is called when a transaction fails with out-of-gas (code 11) so
+// that stale estimates from earlier simulations don't keep causing failures.
+func invalidateGasEstimate(isBridge bool, msg ...sdk.Msg) {
+	if isBridge {
+		delete(gasEstimateMap, BRIDGE_REPORT_TYPE)
+	} else if len(msg) > 0 {
+		delete(gasEstimateMap, reflect.TypeOf(msg[0]))
+	}
+}
+
 func newFactory(clientCtx client.Context) tx.Factory {
 	return tx.Factory{}.
 		WithChainID(clientCtx.ChainID).
 		WithKeybase(clientCtx.Keyring).
-		WithGasAdjustment(1.25).
+		WithGasAdjustment(1.5).
 		WithGas(defaultGas).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT).
 		WithAccountRetriever(clientCtx.AccountRetriever).
@@ -220,12 +232,20 @@ func (c *Client) sendTx(ctx context.Context, queryMetaId uint64, isBridge bool, 
 	}
 	c.logger.Info(fmt.Sprintf("transaction hash: %s", res.TxHash))
 	c.logger.Info(fmt.Sprintf("response after submit message: %d", txnResponse.TxResult.Code))
-	if txnResponse.TxResult.Code == 0 {
-		txSuccess = true // Prevent defer cleanup - keep queryMeta marked as committed
+	switch txnResponse.TxResult.Code {
+	case 0:
+		txSuccess = true
 		telemetry.IncrCounter(1, "daemon_sending_txs", "success")
 		telemetry.IncrCounterWithLabels([]string{"daemon_tx_gas_used_count"}, float32(txnResponse.TxResult.GasUsed), []metrics.Label{{Name: "chain_id", Value: c.cosmosCtx.ChainID}})
+	case 11:
+		// Out of gas: the cached gas estimate is stale. Invalidate it so the
+		// next tx re-simulates against current chain state.
+		invalidateGasEstimate(isBridge, msg...)
+		c.logger.Error("transaction out of gas, invalidated cached gas estimate",
+			"gasWanted", txnResponse.TxResult.GasWanted,
+			"gasUsed", txnResponse.TxResult.GasUsed,
+		)
 	}
-	// If txSuccess stays false, defer will reset commitedIds[queryMetaId]
 
 	return txnResponse, nil
 }


### PR DESCRIPTION
The gas estimate for MsgSubmitValue is simulated once and cached indefinitely in gasEstimateMap. When on-chain gas costs increase (e.g. during cycle list completion, liveness reward distribution, or as the weighted-median aggregate grows), the stale cached estimate causes all subsequent transactions to fail with code 11 (out of gas).

In production this manifests as ~1 hour windows every ~7 hours where 100% of reporter transactions fail, dropping liveness to ~82% during those periods.

Two changes:
- Invalidate the cached gas estimate when a tx returns code 11, so the next transaction re-simulates gas against current chain state
- Increase gas adjustment from 1.25 to 1.5 to provide more headroom for gas cost variability between simulation and execution

Made-with: Cursor