### PR TITLE
fix: pass os.Stdin to keyring for non-interactive environments

### DIFF
--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -241,7 +242,7 @@ func (c *Client) Start(
 	encodingConfig := CreateEncodingConfig()
 	c.cosmosCtx = c.cosmosCtx.WithCodec(encodingConfig.Codec).WithInterfaceRegistry(encodingConfig.InterfaceRegistry).WithTxConfig(encodingConfig.TxConfig)
 
-	kr, err := keyring.New("", kb, homeDir, nil, encodingConfig.Codec)
+	kr, err := keyring.New("", kb, homeDir, os.Stdin, encodingConfig.Codec)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The keyring is initialized with nil as the input reader, which causes keyring-backend file to fail in non-interactive environments (systemd, containers) where stdin is not a TTY but is still needed for passphrase input piping.

Pass os.Stdin instead of nil so the keyring can read from stdin when available, matching the standard Cosmos SDK CLI behavior.

Closes #10

Made-with: Cursor