### PR TITLE
Fix/goroutine tracking and Gas Estimation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog"
@@ -126,6 +127,7 @@ func init() {
 	rootCmd.Flags().Uint32("auto-unbonding-frequency", 0, "Enable automatic unbonding every N days (0 = disabled, 1 - 21 days = valid")
 	rootCmd.Flags().Uint32("auto-unbonding-amount", 0, "Amount of tokens in loya to unbond each unbonding transaction (0 = disabled)")
 	rootCmd.Flags().String("auto-unbonding-max-stake-percentage", "0.0", "Maximum percentage of stake to unbond each unbonding transaction (0 = disabled, 1.0 = 100%). If unbonding amount exceeds this percentage, we will skip the unbonding transaction until it exceeds this percentage again.")
+	rootCmd.Flags().Duration("refresh-gas-estimates-interval", 12*time.Hour, "Interval for resetting cached gas estimates and gas-adjustment levels (<=0 disables)")
 
 	// Marking required flags
 	if err := rootCmd.MarkFlagRequired(flags.FlagHome); err != nil {

--- a/pricefeed/client/client.go
+++ b/pricefeed/client/client.go
@@ -137,6 +137,14 @@ func (c *Client) start(ctx context.Context,
 	exchangeIdToExchangeDetails map[types.ExchangeId]types.ExchangeQueryDetails,
 	subTaskRunner SubTaskRunner,
 ) (err error) {
+	// Release daemonStartup on any exit before the normal "startup complete" point (avoids Stop() blocking forever).
+	startupCompleted := false
+	defer func() {
+		if !startupCompleted {
+			c.daemonStartup.Done()
+		}
+	}()
+
 	// 1. Establish connections to gRPC servers.
 	queryConn, err := grpcClient.NewTcpConnection(ctx, grpcAddress)
 	if err != nil {
@@ -246,6 +254,7 @@ func (c *Client) start(ctx context.Context,
 	// Now that all persistent subtasks have been started and all tickers and stop channels are created,
 	// signal that the startup process is complete. This needs to be called before entering the
 	// price updater loop, which loops indefinitely until the daemon is stopped.
+	startupCompleted = true
 	c.daemonStartup.Done()
 
 	pricefeedClient := servertypes.NewPriceFeedServiceClient(daemonConn)

--- a/pricefeed/client/client_shutdown_test.go
+++ b/pricefeed/client/client_shutdown_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	daemonflags "github.com/tellor-io/layer-daemons/flags"
 	"github.com/tellor-io/layer-daemons/mocks"
 	"github.com/tellor-io/layer-daemons/pricefeed/client/types"
@@ -26,7 +25,7 @@ func TestStop_CompletesWhenStartFailsBeforeDaemonStartupDone(t *testing.T) {
 		mockGrpcClient              *mocks.GrpcClient
 		exchangeIdToQueryConfig     map[types.ExchangeId]*types.ExchangeQueryConfig
 		exchangeIdToExchangeDetails map[types.ExchangeId]types.ExchangeQueryDetails
-		wantErrContains               string
+		wantErrContains             string
 	}{
 		"tcp_connection_fails": {
 			mockGrpcClient: grpc_util.GenerateMockGrpcClientWithOptionalTcpConnectionErrors(

--- a/pricefeed/client/client_shutdown_test.go
+++ b/pricefeed/client/client_shutdown_test.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	daemonflags "github.com/tellor-io/layer-daemons/flags"
+	"github.com/tellor-io/layer-daemons/mocks"
+	"github.com/tellor-io/layer-daemons/pricefeed/client/types"
+	"github.com/tellor-io/layer-daemons/testutil/constants"
+	grpc_util "github.com/tellor-io/layer-daemons/testutil/grpc"
+
+	"cosmossdk.io/log"
+)
+
+// TestStop_CompletesWhenStartFailsBeforeDaemonStartupDone guards the contract that
+// daemonStartup must be released on every early return from start(); otherwise Stop()
+// blocks forever on daemonStartup.Wait().
+func TestStop_CompletesWhenStartFailsBeforeDaemonStartupDone(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		mockGrpcClient              *mocks.GrpcClient
+		exchangeIdToQueryConfig     map[types.ExchangeId]*types.ExchangeQueryConfig
+		exchangeIdToExchangeDetails map[types.ExchangeId]types.ExchangeQueryDetails
+		wantErrContains               string
+	}{
+		"tcp_connection_fails": {
+			mockGrpcClient: grpc_util.GenerateMockGrpcClientWithOptionalTcpConnectionErrors(
+				errors.New(connectionFailsErrorMsg),
+				nil,
+				false,
+			),
+			wantErrContains: connectionFailsErrorMsg,
+		},
+		"grpc_connection_fails": {
+			mockGrpcClient: grpc_util.GenerateMockGrpcClientWithOptionalGrpcConnectionErrors(
+				errors.New(connectionFailsErrorMsg),
+				nil,
+				false,
+			),
+			wantErrContains: connectionFailsErrorMsg,
+		},
+		"empty_exchange_config": {
+			mockGrpcClient: grpc_util.GenerateMockGrpcClientWithOptionalGrpcConnectionErrors(
+				nil,
+				nil,
+				true,
+			),
+			exchangeIdToQueryConfig:     map[types.ExchangeId]*types.ExchangeQueryConfig{},
+			exchangeIdToExchangeDetails: map[types.ExchangeId]types.ExchangeQueryDetails{},
+			wantErrContains:             "exchangeIds must not be empty",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := tc.exchangeIdToQueryConfig
+			details := tc.exchangeIdToExchangeDetails
+			if cfg == nil {
+				cfg = constants.TestExchangeQueryConfigs
+			}
+			if details == nil {
+				details = constants.TestExchangeIdToExchangeQueryDetails
+			}
+
+			faketaskRunner := FakeSubTaskRunner{}
+
+			client := newClient(log.NewNopLogger())
+			err := client.start(
+				grpc_util.Ctx,
+				daemonflags.GetDefaultDaemonFlags(),
+				grpc_util.TcpEndpoint,
+				tc.mockGrpcClient,
+				[]types.MarketParam{},
+				cfg,
+				details,
+				&faketaskRunner,
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErrContains)
+
+			stopDone := make(chan struct{})
+			go func() {
+				client.Stop()
+				close(stopDone)
+			}()
+
+			select {
+			case <-stopDone:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Stop() blocked — daemonStartup was likely not released on failed start()")
+			}
+		})
+	}
+}

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -75,6 +75,9 @@ type Client struct {
 	logger     log.Logger
 	txChan     chan TxChannelInfo
 	PriceGuard *PriceGuard
+	// Gas estimate refresh interval; <=0 disables periodic refresh.
+	refreshGasEstimatesInterval time.Duration
+	gasEstimator                *gasEstimateState
 
 	// Resources that need cleanup
 	grpcConn    *grpc.ClientConn
@@ -101,6 +104,16 @@ func NewClient(logger log.Logger, valGasMin string) *Client {
 		logger:    logger,
 		minGasFee: valGasMin,
 		txChan:    txChan,
+		gasEstimator: newGasEstimateState(map[string]gasBucketConfig{
+			bridgeGasBucketKey: {
+				levels:  []float64{1.75, 2.0},
+				baseIdx: 0,
+			},
+			defaultNonBridgeBucketConfigKey: {
+				levels:  []float64{1.0, 1.25, 2.0},
+				baseIdx: 0,
+			},
+		}),
 	}
 }
 
@@ -190,6 +203,7 @@ func (c *Client) Start(
 	autoUnbondingFrequency := viper.GetUint32("auto-unbonding-frequency")
 	autoUnbondingAmount := viper.GetUint32("auto-unbonding-amount")
 	autoUnbondingMaxStakePercentage := viper.GetString("auto-unbonding-max-stake-percentage")
+	c.refreshGasEstimatesInterval = viper.GetDuration("refresh-gas-estimates-interval")
 
 	if autoUnbondingFrequency > 0 {
 		if autoUnbondingAmount == 0 {
@@ -223,6 +237,11 @@ func (c *Client) Start(
 		)
 	} else {
 		c.logger.Info("Auto unbonding disabled")
+	}
+	if c.refreshGasEstimatesInterval > 0 {
+		c.logger.Info("Periodic gas estimate refresh enabled", "interval", c.refreshGasEstimatesInterval.String())
+	} else {
+		c.logger.Info("Periodic gas estimate refresh disabled")
 	}
 
 	c.cosmosCtx = c.cosmosCtx.WithChainID(chainId)
@@ -332,7 +351,29 @@ func StartReporterDaemonTaskLoop(
 	wg.Add(1)
 	go client.AutoUnbondStakePeriodically(ctx, wg)
 
+	if client.refreshGasEstimatesInterval > 0 {
+		wg.Add(1)
+		go client.RefreshGasEstimatesPeriodically(ctx, wg)
+	}
+
 	wg.Wait()
+}
+
+func (c *Client) RefreshGasEstimatesPeriodically(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+	ticker := time.NewTicker(c.refreshGasEstimatesInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Debug("RefreshGasEstimatesPeriodically: context canceled, exiting")
+			return
+		case <-ticker.C:
+			c.logger.Info("Refreshing gas estimate buckets to base levels")
+			c.resetAllGasLevelsToBase()
+		}
+	}
 }
 
 func (c *Client) checkReporter(ctx context.Context) bool {

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -110,7 +110,7 @@ func NewClient(logger log.Logger, valGasMin string) *Client {
 				baseIdx: 0,
 			},
 			defaultNonBridgeBucketConfigKey: {
-				levels:  []float64{1.0, 1.25, 2.0},
+				levels:  []float64{1.25, 1.6, 2.0},
 				baseIdx: 0,
 			},
 		}),

--- a/reporter/client/tx_handler.go
+++ b/reporter/client/tx_handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	cmttypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -22,10 +23,122 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 )
 
-var (
-	gasEstimateMap     = make(map[reflect.Type]uint64)
-	BRIDGE_REPORT_TYPE = reflect.TypeOf("bridge_deposit_report")
+const (
+	bridgeGasBucketKey              = "bridge"
+	spotPriceGasBucketKey           = "spot-price"
+	defaultNonBridgeBucketConfigKey = "default-non-bridge"
+	outOfGasCode                    = uint32(11)
+	defaultMaxTxAttempts            = 3
 )
+
+type gasBucketConfig struct {
+	levels  []float64
+	baseIdx int
+}
+
+type gasBucketState struct {
+	cachedEstimate uint64
+	hasEstimate    bool
+	levelIdx       int
+}
+
+type gasEstimateState struct {
+	mu          sync.RWMutex
+	configByKey map[string]gasBucketConfig
+	bucketState map[string]gasBucketState
+}
+
+func newGasEstimateState(configByKey map[string]gasBucketConfig) *gasEstimateState {
+	return &gasEstimateState{
+		configByKey: configByKey,
+		bucketState: make(map[string]gasBucketState),
+	}
+}
+
+func (s *gasEstimateState) configForBucket(bucket string) gasBucketConfig {
+	if cfg, ok := s.configByKey[bucket]; ok {
+		return cfg
+	}
+	return s.configByKey[defaultNonBridgeBucketConfigKey]
+}
+
+func (s *gasEstimateState) getOrInitBucketState(bucket string) gasBucketState {
+	cfg := s.configForBucket(bucket)
+	state, ok := s.bucketState[bucket]
+	if !ok {
+		state = gasBucketState{levelIdx: cfg.baseIdx}
+		s.bucketState[bucket] = state
+	}
+	return state
+}
+
+func (s *gasEstimateState) currentGasAdjustment(bucket string) float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.getOrInitBucketState(bucket)
+	cfg := s.configForBucket(bucket)
+	return cfg.levels[state.levelIdx]
+}
+
+func (s *gasEstimateState) getCachedEstimate(bucket string) (uint64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.getOrInitBucketState(bucket)
+	return state.cachedEstimate, state.hasEstimate
+}
+
+func (s *gasEstimateState) setEstimate(bucket string, gas uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.getOrInitBucketState(bucket)
+	state.cachedEstimate = gas
+	state.hasEstimate = true
+	s.bucketState[bucket] = state
+}
+
+func (s *gasEstimateState) escalateGasLevel(bucket string) (bool, float64, float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.getOrInitBucketState(bucket)
+	cfg := s.configForBucket(bucket)
+	from := cfg.levels[state.levelIdx]
+	if state.levelIdx >= len(cfg.levels)-1 {
+		return false, from, from
+	}
+	state.levelIdx++
+	state.hasEstimate = false
+	to := cfg.levels[state.levelIdx]
+	s.bucketState[bucket] = state
+	return true, from, to
+}
+
+func (s *gasEstimateState) setBucketToMaxLevel(bucket string) (float64, float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.getOrInitBucketState(bucket)
+	cfg := s.configForBucket(bucket)
+	from := cfg.levels[state.levelIdx]
+	maxIdx := len(cfg.levels) - 1
+	if state.levelIdx != maxIdx {
+		state.levelIdx = maxIdx
+		state.hasEstimate = false
+		s.bucketState[bucket] = state
+	}
+	to := cfg.levels[state.levelIdx]
+	return from, to
+}
+
+func (s *gasEstimateState) resetAllGasLevelsToBase() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for bucket, state := range s.bucketState {
+		cfg := s.configForBucket(bucket)
+		state.levelIdx = cfg.baseIdx
+		state.hasEstimate = false
+		state.cachedEstimate = 0
+		s.bucketState[bucket] = state
+	}
+}
 
 func newFactory(clientCtx client.Context) tx.Factory {
 	return tx.Factory{}.
@@ -126,35 +239,48 @@ func (c *Client) WaitForBlockHeight(ctx context.Context, h int64) error {
 	}
 }
 
-func (c *Client) EstimateGas(ctx context.Context, isBridge bool, txf tx.Factory, msg ...sdk.Msg) (uint64, error) {
+func (c *Client) bucketForTx(msg sdk.Msg, isBridge bool) string {
 	if isBridge {
-		if gasEstimate, ok := gasEstimateMap[BRIDGE_REPORT_TYPE]; ok {
-			return gasEstimate, nil
-		}
-	} else {
-		msgType := reflect.TypeOf(msg[0])
-		if gasEstimate, ok := gasEstimateMap[msgType]; ok {
-			return gasEstimate, nil
-		}
+		return bridgeGasBucketKey
 	}
-	if isBridge {
-		txf = txf.WithGasAdjustment(1.75)
+	if c.isSpotPriceSubmitValue(msg) {
+		return spotPriceGasBucketKey
 	}
+	return reflect.TypeOf(msg).String()
+}
+
+func (c *Client) isSpotPriceSubmitValue(msg sdk.Msg) bool {
+	submitValueMsg, ok := msg.(interface{ GetQueryData() []byte })
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(c.GetQueryType(submitValueMsg.GetQueryData()), "SpotPrice")
+}
+
+func (c *Client) EstimateGas(ctx context.Context, txf tx.Factory, bucket string, msg ...sdk.Msg) (uint64, error) {
+	if gasEstimate, ok := c.gasEstimator.getCachedEstimate(bucket); ok {
+		return gasEstimate, nil
+	}
+	adjustment := c.gasEstimator.currentGasAdjustment(bucket)
+	txf = txf.WithGasAdjustment(adjustment)
 	_, gasEstimate, err := tx.CalculateGas(c.cosmosCtx, txf, msg...)
 	if err != nil {
 		return 0, fmt.Errorf("error calculating gas: %w", err)
 	}
-	if isBridge {
-		gasEstimateMap[BRIDGE_REPORT_TYPE] = gasEstimate
-	} else {
-		msgType := reflect.TypeOf(msg[0])
-		gasEstimateMap[msgType] = gasEstimate
-	}
+	c.gasEstimator.setEstimate(bucket, gasEstimate)
 	return gasEstimate, nil
+}
+
+func (c *Client) resetAllGasLevelsToBase() {
+	c.gasEstimator.resetAllGasLevelsToBase()
 }
 
 func (c *Client) sendTx(ctx context.Context, queryMetaId uint64, isBridge bool, msg ...sdk.Msg) (*cmttypes.ResultTx, error) {
 	telemetry.IncrCounter(1, "daemon_sending_txs", "called")
+	if len(msg) == 0 {
+		return nil, fmt.Errorf("no messages provided")
+	}
+	bucket := c.bucketForTx(msg[0], isBridge)
 
 	// Track success status for defer cleanup
 	txSuccess := false
@@ -168,9 +294,69 @@ func (c *Client) sendTx(ctx context.Context, queryMetaId uint64, isBridge bool, 
 		}
 	}()
 
+	spotPriceTx := c.isSpotPriceSubmitValue(msg[0])
+	maxAttempts := c.maxAttemptsForTx(msg[0])
+
+	var lastResp *cmttypes.ResultTx
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			c.logger.Info("Retrying tx after out-of-gas", "attempt", attempt, "maxAttempts", maxAttempts, "bucket", bucket)
+		}
+		txnResponse, txHash, err := c.sendTxOnce(ctx, bucket, msg...)
+		if err != nil {
+			return nil, err
+		}
+		lastResp = txnResponse
+		c.logger.Info(fmt.Sprintf("transaction hash: %s", txHash))
+		c.logger.Info(fmt.Sprintf("response after submit message: %d", txnResponse.TxResult.Code))
+
+		if txnResponse.TxResult.Code == 0 {
+			txSuccess = true // Prevent defer cleanup - keep queryMeta marked as committed
+			telemetry.IncrCounter(1, "daemon_sending_txs", "success")
+			telemetry.IncrCounterWithLabels([]string{"daemon_tx_gas_used_count"}, float32(txnResponse.TxResult.GasUsed), []metrics.Label{{Name: "chain_id", Value: c.cosmosCtx.ChainID}})
+			return txnResponse, nil
+		}
+
+		if txnResponse.TxResult.Code != outOfGasCode {
+			return txnResponse, nil
+		}
+
+		changed, from, to := c.gasEstimator.escalateGasLevel(bucket)
+		c.logger.Info("Detected out-of-gas tx response",
+			"code", txnResponse.TxResult.Code,
+			"bucket", bucket,
+			"attempt", attempt,
+			"escalated", changed,
+			"from", from,
+			"to", to,
+		)
+		if !changed {
+			return txnResponse, nil
+		}
+	}
+
+	if spotPriceTx {
+		from, to := c.gasEstimator.setBucketToMaxLevel(bucket)
+		c.logger.Info("Skipping third spot price send attempt after two failures",
+			"bucket", bucket,
+			"from", from,
+			"to", to,
+		)
+	}
+	return lastResp, nil
+}
+
+func (c *Client) maxAttemptsForTx(msg sdk.Msg) int {
+	if c.isSpotPriceSubmitValue(msg) {
+		return 2
+	}
+	return defaultMaxTxAttempts
+}
+
+func (c *Client) sendTxOnce(ctx context.Context, bucket string, msg ...sdk.Msg) (*cmttypes.ResultTx, string, error) {
 	block, err := c.CmtService.GetLatestBlock(ctx, &cmtservice.GetLatestBlockRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("error getting block: %w", err)
+		return nil, "", fmt.Errorf("error getting block: %w", err)
 	}
 	txf := newFactory(c.cosmosCtx)
 
@@ -184,32 +370,32 @@ func (c *Client) sendTx(ctx context.Context, queryMetaId uint64, isBridge bool, 
 		WithTimeoutTimestamp(c.GetUniqueUnorderedTimeout())
 	txf, err = txf.Prepare(c.cosmosCtx)
 	if err != nil {
-		return nil, fmt.Errorf("error preparing transaction factory: %w", err)
+		return nil, "", fmt.Errorf("error preparing transaction factory: %w", err)
 	}
-	gasEstimate, err := c.EstimateGas(ctx, isBridge, txf, msg...)
+	gasEstimate, err := c.EstimateGas(ctx, txf, bucket, msg...)
 	if err == nil {
 		txf = txf.WithGas(gasEstimate)
 	}
 	txn, err := txf.BuildUnsignedTx(msg...)
 	if err != nil {
-		return nil, fmt.Errorf("error building unsigned transaction: %w", err)
+		return nil, "", fmt.Errorf("error building unsigned transaction: %w", err)
 	}
 	if err = tx.Sign(c.cosmosCtx.CmdContext, txf, c.cosmosCtx.FromName, txn, true); err != nil {
-		return nil, fmt.Errorf("error when signing transaction: %w", err)
+		return nil, "", fmt.Errorf("error when signing transaction: %w", err)
 	}
 
 	txBytes, err := c.cosmosCtx.TxConfig.TxEncoder()(txn.GetTx())
 	if err != nil {
-		return nil, fmt.Errorf("error encoding transaction: %w", err)
+		return nil, "", fmt.Errorf("error encoding transaction: %w", err)
 	}
 	res, err := c.cosmosCtx.BroadcastTx(txBytes)
 	if err := handleBroadcastResult(res, err); err != nil {
-		return nil, fmt.Errorf("error broadcasting transaction result: %w", err)
+		return nil, "", fmt.Errorf("error broadcasting transaction result: %w", err)
 	}
 
 	txnResponse, err := c.WaitForTx(ctx, res.TxHash)
 	if err != nil {
-		return nil, fmt.Errorf("error waiting for transaction: %w", err)
+		return nil, "", fmt.Errorf("error waiting for transaction: %w", err)
 	}
 	for _, event := range txnResponse.TxResult.Events {
 		if event.Type == "new_report" {
@@ -218,16 +404,7 @@ func (c *Client) sendTx(ctx context.Context, queryMetaId uint64, isBridge bool, 
 			}
 		}
 	}
-	c.logger.Info(fmt.Sprintf("transaction hash: %s", res.TxHash))
-	c.logger.Info(fmt.Sprintf("response after submit message: %d", txnResponse.TxResult.Code))
-	if txnResponse.TxResult.Code == 0 {
-		txSuccess = true // Prevent defer cleanup - keep queryMeta marked as committed
-		telemetry.IncrCounter(1, "daemon_sending_txs", "success")
-		telemetry.IncrCounterWithLabels([]string{"daemon_tx_gas_used_count"}, float32(txnResponse.TxResult.GasUsed), []metrics.Label{{Name: "chain_id", Value: c.cosmosCtx.ChainID}})
-	}
-	// If txSuccess stays false, defer will reset commitedIds[queryMetaId]
-
-	return txnResponse, nil
+	return txnResponse, res.TxHash, nil
 }
 
 func (c *Client) SetGasPrice(ctx context.Context) error {

--- a/reporter/client/tx_handler_test.go
+++ b/reporter/client/tx_handler_test.go
@@ -1,0 +1,131 @@
+package client
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/stretchr/testify/require"
+	oracletypes "github.com/tellor-io/layer/x/oracle/types"
+
+	"cosmossdk.io/log"
+)
+
+func TestGasEstimatorEscalation_NonBridge(t *testing.T) {
+	c := NewClient(log.NewNopLogger(), "0.001loya")
+	bucket := "test-non-bridge"
+
+	require.Equal(t, 1.0, c.gasEstimator.currentGasAdjustment(bucket))
+	changed, from, to := c.gasEstimator.escalateGasLevel(bucket)
+	require.True(t, changed)
+	require.Equal(t, 1.0, from)
+	require.Equal(t, 1.25, to)
+	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(bucket))
+
+	changed, from, to = c.gasEstimator.escalateGasLevel(bucket)
+	require.True(t, changed)
+	require.Equal(t, 1.25, from)
+	require.Equal(t, 2.0, to)
+	require.Equal(t, 2.0, c.gasEstimator.currentGasAdjustment(bucket))
+
+	changed, from, to = c.gasEstimator.escalateGasLevel(bucket)
+	require.False(t, changed)
+	require.Equal(t, 2.0, from)
+	require.Equal(t, 2.0, to)
+}
+
+func TestGasEstimatorEscalation_Bridge(t *testing.T) {
+	c := NewClient(log.NewNopLogger(), "0.001loya")
+
+	require.Equal(t, 1.75, c.gasEstimator.currentGasAdjustment(bridgeGasBucketKey))
+	changed, from, to := c.gasEstimator.escalateGasLevel(bridgeGasBucketKey)
+	require.True(t, changed)
+	require.Equal(t, 1.75, from)
+	require.Equal(t, 2.0, to)
+
+	changed, from, to = c.gasEstimator.escalateGasLevel(bridgeGasBucketKey)
+	require.False(t, changed)
+	require.Equal(t, 2.0, from)
+	require.Equal(t, 2.0, to)
+}
+
+func TestEscalationAffectsOnlyRelevantBucket(t *testing.T) {
+	c := NewClient(log.NewNopLogger(), "0.001loya")
+
+	otherBucket := "*oracletypes.MsgWithdrawTip"
+	require.Equal(t, 1.0, c.gasEstimator.currentGasAdjustment(otherBucket))
+
+	changed, _, _ := c.gasEstimator.escalateGasLevel(spotPriceGasBucketKey)
+	require.True(t, changed)
+	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(spotPriceGasBucketKey))
+	require.Equal(t, 1.0, c.gasEstimator.currentGasAdjustment(otherBucket))
+}
+
+func TestRetryPolicyMatrix(t *testing.T) {
+	c := NewClient(log.NewNopLogger(), "0.001loya")
+
+	spotMsg := &oracletypes.MsgSubmitValue{
+		Creator:   "reporter",
+		QueryData: mustEncodeQueryData(t, "SpotPrice"),
+		Value:     "0x1234",
+	}
+	nonSpotMsg := &oracletypes.MsgSubmitValue{
+		Creator:   "reporter",
+		QueryData: mustEncodeQueryData(t, "TRBBridgeV2"),
+		Value:     "0x1234",
+	}
+
+	require.Equal(t, 2, c.maxAttemptsForTx(spotMsg))
+	require.Equal(t, 3, c.maxAttemptsForTx(nonSpotMsg))
+}
+
+func TestResetAllGasLevelsToBase_IsLazy(t *testing.T) {
+	c := NewClient(log.NewNopLogger(), "0.001loya")
+	bucket := "lazy-reset"
+
+	c.gasEstimator.setEstimate(bucket, 111)
+	changed, _, _ := c.gasEstimator.escalateGasLevel(bucket)
+	require.True(t, changed)
+	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(bucket))
+	estimate, ok := c.gasEstimator.getCachedEstimate(bucket)
+	require.False(t, ok)
+	require.Equal(t, uint64(111), estimate)
+
+	c.resetAllGasLevelsToBase()
+	require.Equal(t, 1.0, c.gasEstimator.currentGasAdjustment(bucket))
+	_, ok = c.gasEstimator.getCachedEstimate(bucket)
+	require.False(t, ok)
+}
+
+func TestGasEstimatorConcurrentAccess(t *testing.T) {
+	c := NewClient(log.NewNopLogger(), "0.001loya")
+	bucket := "concurrent"
+
+	var wg sync.WaitGroup
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			c.gasEstimator.setEstimate(bucket, uint64(100+idx))
+			c.gasEstimator.currentGasAdjustment(bucket)
+			c.gasEstimator.escalateGasLevel(bucket)
+			c.gasEstimator.getCachedEstimate(bucket)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func mustEncodeQueryData(t *testing.T, queryType string) []byte {
+	t.Helper()
+	stringType, err := abi.NewType("string", "", nil)
+	require.NoError(t, err)
+	bytesType, err := abi.NewType("bytes", "", nil)
+	require.NoError(t, err)
+	args := abi.Arguments{
+		{Type: stringType},
+		{Type: bytesType},
+	}
+	bz, err := args.Pack(queryType, []byte("args"))
+	require.NoError(t, err)
+	return bz
+}

--- a/reporter/client/tx_handler_test.go
+++ b/reporter/client/tx_handler_test.go
@@ -15,16 +15,16 @@ func TestGasEstimatorEscalation_NonBridge(t *testing.T) {
 	c := NewClient(log.NewNopLogger(), "0.001loya")
 	bucket := "test-non-bridge"
 
-	require.Equal(t, 1.0, c.gasEstimator.currentGasAdjustment(bucket))
+	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(bucket))
 	changed, from, to := c.gasEstimator.escalateGasLevel(bucket)
 	require.True(t, changed)
-	require.Equal(t, 1.0, from)
-	require.Equal(t, 1.25, to)
-	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(bucket))
+	require.Equal(t, 1.25, from)
+	require.Equal(t, 1.6, to)
+	require.Equal(t, 1.6, c.gasEstimator.currentGasAdjustment(bucket))
 
 	changed, from, to = c.gasEstimator.escalateGasLevel(bucket)
 	require.True(t, changed)
-	require.Equal(t, 1.25, from)
+	require.Equal(t, 1.6, from)
 	require.Equal(t, 2.0, to)
 	require.Equal(t, 2.0, c.gasEstimator.currentGasAdjustment(bucket))
 
@@ -53,12 +53,12 @@ func TestEscalationAffectsOnlyRelevantBucket(t *testing.T) {
 	c := NewClient(log.NewNopLogger(), "0.001loya")
 
 	otherBucket := "*oracletypes.MsgWithdrawTip"
-	require.Equal(t, 1.0, c.gasEstimator.currentGasAdjustment(otherBucket))
+	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(otherBucket))
 
 	changed, _, _ := c.gasEstimator.escalateGasLevel(spotPriceGasBucketKey)
 	require.True(t, changed)
-	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(spotPriceGasBucketKey))
-	require.Equal(t, 1.0, c.gasEstimator.currentGasAdjustment(otherBucket))
+	require.Equal(t, 1.6, c.gasEstimator.currentGasAdjustment(spotPriceGasBucketKey))
+	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(otherBucket))
 }
 
 func TestRetryPolicyMatrix(t *testing.T) {
@@ -86,13 +86,13 @@ func TestResetAllGasLevelsToBase_IsLazy(t *testing.T) {
 	c.gasEstimator.setEstimate(bucket, 111)
 	changed, _, _ := c.gasEstimator.escalateGasLevel(bucket)
 	require.True(t, changed)
-	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(bucket))
+	require.Equal(t, 1.6, c.gasEstimator.currentGasAdjustment(bucket))
 	estimate, ok := c.gasEstimator.getCachedEstimate(bucket)
 	require.False(t, ok)
 	require.Equal(t, uint64(111), estimate)
 
 	c.resetAllGasLevelsToBase()
-	require.Equal(t, 1.0, c.gasEstimator.currentGasAdjustment(bucket))
+	require.Equal(t, 1.25, c.gasEstimator.currentGasAdjustment(bucket))
 	_, ok = c.gasEstimator.getCachedEstimate(bucket)
 	require.False(t, ok)
 }

--- a/token_bridge_feed/client/client.go
+++ b/token_bridge_feed/client/client.go
@@ -72,6 +72,40 @@ func StartNewClient(ctx context.Context, logger log.Logger, tokenDepositsCache *
 	return client
 }
 
+// waitForContractInitialized polls until query returns (true, nil), or ctx ends.
+// On query errors it waits retryDelay between attempts (interruptible by ctx).
+func waitForContractInitialized(ctx context.Context, logger log.Logger, retryDelay time.Duration, query func() (bool, error)) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			logger.Debug("TokenBridgeClient: context canceled during contract init wait")
+			return err
+		}
+
+		initialized, err := query()
+		if err != nil {
+			logger.Error("Failed to check initialization status, retrying...", "error", err)
+			select {
+			case <-ctx.Done():
+				logger.Debug("TokenBridgeClient: context canceled during contract init wait")
+				return ctx.Err()
+			case <-time.After(retryDelay):
+			}
+			continue
+		}
+		if initialized {
+			logger.Info("Contract is initialized, starting deposit monitoring")
+			return nil
+		}
+		logger.Info("Contract not yet initialized, waiting...")
+		select {
+		case <-ctx.Done():
+			logger.Debug("TokenBridgeClient: context canceled during contract init wait")
+			return ctx.Err()
+		case <-time.After(retryDelay):
+		}
+	}
+}
+
 func newClient(logger log.Logger, tokenDepositsCache *tokenbridgetypes.DepositReports, tokenBridgeTipsCache *tokenbridgetipstypes.DepositTips) *Client {
 	logger = logger.With(log.ModuleKey, "tokenbridge-daemon")
 	client := &Client{
@@ -88,35 +122,34 @@ func newClient(logger log.Logger, tokenDepositsCache *tokenbridgetypes.DepositRe
 }
 
 func (c *Client) start(ctx context.Context) {
+	// If we exit before signaling startup complete, Stop() must not block on daemonStartup forever.
+	startupSignaled := false
+	defer func() {
+		if !startupSignaled {
+			c.daemonStartup.Done()
+		}
+	}()
+
 	// Initialize clients and contracts first (needed to check initialization status)
 	if err := c.initializeClientsAndContracts(); err != nil {
 		c.logger.Error("Failed to initialize clients and contracts", "error", err)
 		return
 	}
 
+	const initRetryDelay = 2 * time.Minute
+
 	// Wait for contract to be initialized before starting the main loop
 	c.logger.Info("Waiting for contract to be initialized...")
-	for {
-		initialized, err := c.QueryHasContractBeenInitialized()
-		if err != nil {
-			c.logger.Error("Failed to check initialization status, retrying...", "error", err)
-			time.Sleep(2 * time.Minute)
-			continue
-		}
-		if initialized {
-			c.logger.Info("Contract is initialized, starting deposit monitoring")
-			break
-		}
-		c.logger.Info("Contract not yet initialized, waiting...")
-		time.Sleep(2 * time.Minute)
+	if err := waitForContractInitialized(ctx, c.logger, initRetryDelay, c.QueryHasContractBeenInitialized); err != nil {
+		return
 	}
 
 	if err := c.InitializeDeposits(); err != nil {
 		c.logger.Error("Failed to initialize deposits", "error", err)
-		c.daemonStartup.Done()
 		return
 	}
 	// Mark startup as complete after initialization
+	startupSignaled = true
 	c.daemonStartup.Done()
 
 	ticker := time.NewTicker(10 * time.Second)

--- a/token_bridge_feed/client/client_shutdown_test.go
+++ b/token_bridge_feed/client/client_shutdown_test.go
@@ -1,0 +1,86 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	tokenbridgetypes "github.com/tellor-io/layer-daemons/server/types/token_bridge"
+	tokenbridgetipstypes "github.com/tellor-io/layer-daemons/server/types/token_bridge_tips"
+
+	"cosmossdk.io/log"
+)
+
+func TestWaitForContractInitialized_ReturnsWhenContextAlreadyCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := waitForContractInitialized(ctx, log.NewNopLogger(), time.Hour, func() (bool, error) {
+		return false, nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWaitForContractInitialized_ReturnsNilWhenInitialized(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var calls atomic.Int32
+	err := waitForContractInitialized(ctx, log.NewNopLogger(), time.Millisecond, func() (bool, error) {
+		calls.Add(1)
+		return true, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestWaitForContractInitialized_ReturnsWhenContextCanceledDuringRetryDelay(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- waitForContractInitialized(ctx, log.NewNopLogger(), 500*time.Millisecond, func() (bool, error) {
+			return false, errors.New("transient")
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForContractInitialized did not return after cancel during retry sleep")
+	}
+}
+
+// TestStartNewClient_StopUnblocksWhenEthereumEnvIncomplete covers the path where
+// initializeClientsAndContracts fails before daemonStartup is signaled; Stop() must
+// not block forever on daemonStartup.Wait().
+func TestStartNewClient_StopUnblocksWhenEthereumEnvIncomplete(t *testing.T) {
+	t.Setenv("ETH_RPC_URL_PRIMARY", "")
+	t.Setenv("ETH_RPC_URL_FALLBACK", "")
+
+	ctx := context.Background()
+	c := StartNewClient(ctx, log.NewNopLogger(), tokenbridgetypes.NewDepositReports(), tokenbridgetipstypes.NewDepositTips())
+
+	stopDone := make(chan struct{})
+	go func() {
+		c.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop() blocked after init failure — daemonStartup / waitgroup regression")
+	}
+}


### PR DESCRIPTION
Improved go routine tracking to allow for a proper shutdown. Implemented a dynamic gas pricing system with 3 levels of gasAdjustment used during the gas estimation function. Default is 1.25 then if a code 11 (out of gas error) is returned in a transaction response we go up to 1.6 and then finally up to 2.0 if we still are seeing code 11's. Also automatic retry of transaction with higher gas.
Added flag (--refresh-gas-estimates-interval 30m) where you can set how frequently you want your gas estimate cache to reset so that you are not stuck paying higher gas fees forever unless you restart your reporter
