### PR TITLE
improved variable handling

### DIFF
--- a/app.go
+++ b/app.go
@@ -174,7 +174,7 @@ func NewApp(
 		}
 	}()
 
-	tokenBridgeClient := tokenbridgeclient.StartNewClient(ctx, logger, tokenDepositsCache, tokenBridgeTipsCache)
+	tokenBridgeClient := tokenbridgeclient.StartNewClient(ctx, logger, tokenDepositsCache, tokenBridgeTipsCache, chainId)
 	appInstance.TokenBridgeClient = tokenBridgeClient
 
 	// Start the Metrics Daemon.

--- a/custom_query/README.md
+++ b/custom_query/README.md
@@ -25,6 +25,12 @@ Each endpoint represents an API source:
 url_template = "https://api.coingecko.com/api/v3/simple/price?ids={coin_id}&vs_currencies=usd"
 method = "GET"
 timeout = 5000
+
+[endpoints.coingeckoPro]
+url_template = "https://pro-api.coingecko.com/api/v3/simple/price?ids={coin_id}&vs_currencies=usd&x_cg_pro_api_key={api_key}"
+method = "GET"
+timeout = 5000
+api_key = "${CGPRO_API_KEY}"
 ```
 
 Endpoints support:
@@ -33,6 +39,8 @@ Endpoints support:
 - Custom timeouts
 - API keys via environment variables (`${ENV_VAR_NAME}`)
 - Custom headers
+
+For generated defaults that use Coingecko Pro, set `CGPRO_API_KEY` in your `.env` file. See [`../env.example`](../env.example) for the expected variable names.
 
 ### 2. Queries
 

--- a/custom_query/constants.go
+++ b/custom_query/constants.go
@@ -8,6 +8,12 @@ var StaticEndpointTemplateConfig = map[string]*EndpointTemplate{
 		Method:      "GET",
 		Timeout:     5000,
 	},
+	"coingeckoPro": {
+		URLTemplate: "https://pro-api.coingecko.com/api/v3/simple/price?ids={coin_id}&vs_currencies=usd&x_cg_pro_api_key={api_key}",
+		Method:      "GET",
+		Timeout:     5000,
+		ApiKey:      "${CGPRO_API_KEY}",
+	},
 	"coinpaprika": {
 		URLTemplate: "https://api.coinpaprika.com/v1/tickers/{coin_id}?quotes=USD",
 		Method:      "GET",
@@ -121,7 +127,7 @@ var StaticQueriesConfig = map[string]*QueryConfig{
 		ResponseType:      "ufixed256x18",
 		Endpoints: []EndpointConfig{
 			{
-				EndpointType: "coingecko",
+				EndpointType: "coingeckoPro",
 				ResponsePath: []string{"noble-dollar-usdn", "usd"},
 				Params: map[string]string{
 					"coin_id": "noble-dollar-usdn",
@@ -147,7 +153,7 @@ var StaticQueriesConfig = map[string]*QueryConfig{
 		ResponseType:      "ufixed256x18",
 		Endpoints: []EndpointConfig{
 			{
-				EndpointType: "coingecko",
+				EndpointType: "coingeckoPro",
 				ResponsePath: []string{"susds", "usd"},
 				Params: map[string]string{
 					"coin_id": "susds",
@@ -258,7 +264,7 @@ var StaticQueriesConfig = map[string]*QueryConfig{
 		ResponseType:      "ufixed256x18",
 		Endpoints: []EndpointConfig{
 			{
-				EndpointType: "coingecko",
+				EndpointType: "coingeckoPro",
 				ResponsePath: []string{"lrt-squared", "usd"},
 				Params: map[string]string{
 					"coin_id": "lrt-squared",

--- a/env.example
+++ b/env.example
@@ -1,0 +1,28 @@
+# Copy this file to .env and fill in values for the services you run.
+# The daemon loads .env from the current directory, or ../.env when run from a subdirectory.
+
+# Token bridge daemon
+# Required for token bridge deposit monitoring. Use separate providers for primary and fallback.
+ETH_RPC_URL_PRIMARY=https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY
+ETH_RPC_URL_FALLBACK=https://eth-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_API_KEY
+
+# Used automatically based on the --chain-id flag.
+TELLOR_1_TOKEN_BRIDGE=0x6ec401744008f4B018Ed9A36f76e6629799Ee50E
+LAYERTEST_5_TOKEN_BRIDGE=0x55355157703A44f7516FBB831333317E98944e32
+
+# Optional fallback for local/custom chains.
+# TOKEN_BRIDGE_CONTRACT=0x0000000000000000000000000000000000000000
+
+# Reporter rewards and auto-unbonding
+# REPORTERS_VALIDATOR_ADDRESS is required for auto reward withdrawals and auto unbonding.
+# WITHDRAW_FREQUENCY is in seconds and defaults to 43200 (12 hours) when unset.
+REPORTERS_VALIDATOR_ADDRESS=tellorvaloper1...
+WITHDRAW_FREQUENCY=43200
+
+# Custom query API keys
+# These are used by generated custom_query_config.toml entries that reference ${VAR}.
+CMC_PRO_API_KEY=your_coinmarketcap_api_key
+CGPRO_API_KEY=your_coingecko_pro_api_key
+SUBGRAPH_API_KEY=your_the_graph_api_key
+INFURA_API_KEY=your_infura_api_key
+ALCHEMY_API_KEY=your_alchemy_api_key

--- a/env.example
+++ b/env.example
@@ -6,12 +6,10 @@
 ETH_RPC_URL_PRIMARY=https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY
 ETH_RPC_URL_FALLBACK=https://eth-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_API_KEY
 
-# Used automatically based on the --chain-id flag.
-TELLOR_1_TOKEN_BRIDGE=0x6ec401744008f4B018Ed9A36f76e6629799Ee50E
-LAYERTEST_5_TOKEN_BRIDGE=0x55355157703A44f7516FBB831333317E98944e32
+# Token bridge contracts are hard-coded for tellor-1 and layertest-5.
 
 # Optional fallback for local/custom chains.
-# TOKEN_BRIDGE_CONTRACT=0x0000000000000000000000000000000000000000
+# TOKEN_BRIDGE_TEST_CONTRACT=0x0000000000000000000000000000000000000000
 
 # Reporter rewards and auto-unbonding
 # REPORTERS_VALIDATOR_ADDRESS is required for auto reward withdrawals and auto unbonding.

--- a/token_bridge_feed/client/client.go
+++ b/token_bridge_feed/client/client.go
@@ -39,11 +39,11 @@ type Client struct {
 	fallbackBridgeContract *tokenbridge.TokenBridgeV2
 }
 
-const legacyTokenBridgeContractEnv = "TOKEN_BRIDGE_CONTRACT"
+const tokenBridgeTestContractEnv = "TOKEN_BRIDGE_TEST_CONTRACT"
 
-var tokenBridgeContractEnvByChainID = map[string]string{
-	"tellor-1":    "TELLOR_1_TOKEN_BRIDGE",
-	"layertest-5": "LAYERTEST_5_TOKEN_BRIDGE",
+var tokenBridgeContractByChainID = map[string]string{
+	"tellor-1":    "0x6ec401744008f4B018Ed9A36f76e6629799Ee50E",
+	"layertest-5": "0x55355157703A44f7516FBB831333317E98944e32",
 }
 
 type DepositReceipt struct {
@@ -547,26 +547,19 @@ func (c *Client) EncodeReportValue(depositReceipt DepositReceipt) ([]byte, error
 
 func (c *Client) getTokenBridgeContractAddress() (common.Address, error) {
 	chainID := strings.ToLower(strings.TrimSpace(c.chainID))
-	if envVar, ok := tokenBridgeContractEnvByChainID[chainID]; ok {
-		tokenBridgeContractAddress := strings.TrimSpace(os.Getenv(envVar))
-		if tokenBridgeContractAddress == "" {
-			return common.Address{}, fmt.Errorf("%s not set for chain ID %s", envVar, c.chainID)
-		}
-		if !common.IsHexAddress(tokenBridgeContractAddress) {
-			return common.Address{}, fmt.Errorf("%s is not a valid ethereum address", envVar)
-		}
-		c.logger.Info("Using token bridge contract", "chain_id", c.chainID, "env_var", envVar, "address", tokenBridgeContractAddress)
+	if tokenBridgeContractAddress, ok := tokenBridgeContractByChainID[chainID]; ok {
+		c.logger.Info("Using token bridge contract", "chain_id", c.chainID, "address", tokenBridgeContractAddress)
 		return common.HexToAddress(tokenBridgeContractAddress), nil
 	}
 
-	tokenBridgeContractAddress := strings.TrimSpace(os.Getenv(legacyTokenBridgeContractEnv))
+	tokenBridgeContractAddress := strings.TrimSpace(os.Getenv(tokenBridgeTestContractEnv))
 	if tokenBridgeContractAddress == "" {
-		return common.Address{}, fmt.Errorf("unsupported chain ID %q for token bridge contract; set %s for local/custom chains", c.chainID, legacyTokenBridgeContractEnv)
+		return common.Address{}, fmt.Errorf("unsupported chain ID %q for token bridge contract; set %s for local/custom chains", c.chainID, tokenBridgeTestContractEnv)
 	}
 	if !common.IsHexAddress(tokenBridgeContractAddress) {
-		return common.Address{}, fmt.Errorf("%s is not a valid ethereum address", legacyTokenBridgeContractEnv)
+		return common.Address{}, fmt.Errorf("%s is not a valid ethereum address", tokenBridgeTestContractEnv)
 	}
-	c.logger.Info("Using fallback token bridge contract", "chain_id", c.chainID, "env_var", legacyTokenBridgeContractEnv, "address", tokenBridgeContractAddress)
+	c.logger.Info("Using fallback token bridge contract", "chain_id", c.chainID, "env_var", tokenBridgeTestContractEnv, "address", tokenBridgeContractAddress)
 	return common.HexToAddress(tokenBridgeContractAddress), nil
 }
 

--- a/token_bridge_feed/client/client.go
+++ b/token_bridge_feed/client/client.go
@@ -27,6 +27,7 @@ type Client struct {
 	logger                   log.Logger
 	tokenDepositsCache       *tokenbridgetypes.DepositReports
 	tokenBridgeTipsCache     *tokenbridgetipstypes.DepositTips
+	chainID                  string
 	daemonStartup            sync.WaitGroup
 	runningSubtasksWaitGroup sync.WaitGroup
 	tickers                  []*time.Ticker
@@ -36,6 +37,13 @@ type Client struct {
 	fallbackEthClient      *ethclient.Client
 	primaryBridgeContract  *tokenbridge.TokenBridgeV2
 	fallbackBridgeContract *tokenbridge.TokenBridgeV2
+}
+
+const legacyTokenBridgeContractEnv = "TOKEN_BRIDGE_CONTRACT"
+
+var tokenBridgeContractEnvByChainID = map[string]string{
+	"tellor-1":    "TELLOR_1_TOKEN_BRIDGE",
+	"layertest-5": "LAYERTEST_5_TOKEN_BRIDGE",
 }
 
 type DepositReceipt struct {
@@ -60,10 +68,10 @@ type APIResponse struct {
 	} `json:"data"`
 }
 
-func StartNewClient(ctx context.Context, logger log.Logger, tokenDepositsCache *tokenbridgetypes.DepositReports, tokenBridgeTipsCache *tokenbridgetipstypes.DepositTips) *Client {
+func StartNewClient(ctx context.Context, logger log.Logger, tokenDepositsCache *tokenbridgetypes.DepositReports, tokenBridgeTipsCache *tokenbridgetipstypes.DepositTips, chainID string) *Client {
 	logger.Info("Starting tokenbridge daemon")
 
-	client := newClient(logger, tokenDepositsCache, tokenBridgeTipsCache)
+	client := newClient(logger, tokenDepositsCache, tokenBridgeTipsCache, chainID)
 	client.runningSubtasksWaitGroup.Add(1)
 	go func() {
 		defer client.runningSubtasksWaitGroup.Done()
@@ -106,7 +114,7 @@ func waitForContractInitialized(ctx context.Context, logger log.Logger, retryDel
 	}
 }
 
-func newClient(logger log.Logger, tokenDepositsCache *tokenbridgetypes.DepositReports, tokenBridgeTipsCache *tokenbridgetipstypes.DepositTips) *Client {
+func newClient(logger log.Logger, tokenDepositsCache *tokenbridgetypes.DepositReports, tokenBridgeTipsCache *tokenbridgetipstypes.DepositTips, chainID string) *Client {
 	logger = logger.With(log.ModuleKey, "tokenbridge-daemon")
 	client := &Client{
 		tickers:              []*time.Ticker{},
@@ -114,6 +122,7 @@ func newClient(logger log.Logger, tokenDepositsCache *tokenbridgetypes.DepositRe
 		logger:               logger,
 		tokenDepositsCache:   tokenDepositsCache,
 		tokenBridgeTipsCache: tokenBridgeTipsCache,
+		chainID:              strings.TrimSpace(chainID),
 	}
 
 	// Set the client's daemonStartup state to indicate that the daemon has not finished starting up.
@@ -537,12 +546,27 @@ func (c *Client) EncodeReportValue(depositReceipt DepositReceipt) ([]byte, error
 }
 
 func (c *Client) getTokenBridgeContractAddress() (common.Address, error) {
-	tokenBridgeContractAddress := os.Getenv("TOKEN_BRIDGE_CONTRACT")
-	if tokenBridgeContractAddress == "" {
-		return common.Address{}, fmt.Errorf("TOKEN_BRIDGE_CONTRACT not set")
-	} else {
-		fmt.Println("TOKEN_BRIDGE_CONTRACT", tokenBridgeContractAddress)
+	chainID := strings.ToLower(strings.TrimSpace(c.chainID))
+	if envVar, ok := tokenBridgeContractEnvByChainID[chainID]; ok {
+		tokenBridgeContractAddress := strings.TrimSpace(os.Getenv(envVar))
+		if tokenBridgeContractAddress == "" {
+			return common.Address{}, fmt.Errorf("%s not set for chain ID %s", envVar, c.chainID)
+		}
+		if !common.IsHexAddress(tokenBridgeContractAddress) {
+			return common.Address{}, fmt.Errorf("%s is not a valid ethereum address", envVar)
+		}
+		c.logger.Info("Using token bridge contract", "chain_id", c.chainID, "env_var", envVar, "address", tokenBridgeContractAddress)
+		return common.HexToAddress(tokenBridgeContractAddress), nil
 	}
+
+	tokenBridgeContractAddress := strings.TrimSpace(os.Getenv(legacyTokenBridgeContractEnv))
+	if tokenBridgeContractAddress == "" {
+		return common.Address{}, fmt.Errorf("unsupported chain ID %q for token bridge contract; set %s for local/custom chains", c.chainID, legacyTokenBridgeContractEnv)
+	}
+	if !common.IsHexAddress(tokenBridgeContractAddress) {
+		return common.Address{}, fmt.Errorf("%s is not a valid ethereum address", legacyTokenBridgeContractEnv)
+	}
+	c.logger.Info("Using fallback token bridge contract", "chain_id", c.chainID, "env_var", legacyTokenBridgeContractEnv, "address", tokenBridgeContractAddress)
 	return common.HexToAddress(tokenBridgeContractAddress), nil
 }
 

--- a/token_bridge_feed/client/client_shutdown_test.go
+++ b/token_bridge_feed/client/client_shutdown_test.go
@@ -70,7 +70,7 @@ func TestStartNewClient_StopUnblocksWhenEthereumEnvIncomplete(t *testing.T) {
 	t.Setenv("ETH_RPC_URL_FALLBACK", "")
 
 	ctx := context.Background()
-	c := StartNewClient(ctx, log.NewNopLogger(), tokenbridgetypes.NewDepositReports(), tokenbridgetipstypes.NewDepositTips())
+	c := StartNewClient(ctx, log.NewNopLogger(), tokenbridgetypes.NewDepositReports(), tokenbridgetipstypes.NewDepositTips(), "tellor-1")
 
 	stopDone := make(chan struct{})
 	go func() {
@@ -83,4 +83,24 @@ func TestStartNewClient_StopUnblocksWhenEthereumEnvIncomplete(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("Stop() blocked after init failure — daemonStartup / waitgroup regression")
 	}
+}
+
+func TestGetTokenBridgeContractAddress_UsesChainSpecificEnv(t *testing.T) {
+	t.Setenv("TELLOR_1_TOKEN_BRIDGE", "0x6ec401744008f4B018Ed9A36f76e6629799Ee50E")
+
+	c := newClient(log.NewNopLogger(), tokenbridgetypes.NewDepositReports(), tokenbridgetipstypes.NewDepositTips(), "tellor-1")
+	address, err := c.getTokenBridgeContractAddress()
+
+	require.NoError(t, err)
+	require.Equal(t, "0x6ec401744008f4B018Ed9A36f76e6629799Ee50E", address.Hex())
+}
+
+func TestGetTokenBridgeContractAddress_UsesFallbackForCustomChain(t *testing.T) {
+	t.Setenv("TOKEN_BRIDGE_CONTRACT", "0x55355157703A44f7516FBB831333317E98944e32")
+
+	c := newClient(log.NewNopLogger(), tokenbridgetypes.NewDepositReports(), tokenbridgetipstypes.NewDepositTips(), "localnet")
+	address, err := c.getTokenBridgeContractAddress()
+
+	require.NoError(t, err)
+	require.Equal(t, "0x55355157703A44f7516FBB831333317E98944e32", address.Hex())
 }

--- a/token_bridge_feed/client/client_shutdown_test.go
+++ b/token_bridge_feed/client/client_shutdown_test.go
@@ -85,9 +85,7 @@ func TestStartNewClient_StopUnblocksWhenEthereumEnvIncomplete(t *testing.T) {
 	}
 }
 
-func TestGetTokenBridgeContractAddress_UsesChainSpecificEnv(t *testing.T) {
-	t.Setenv("TELLOR_1_TOKEN_BRIDGE", "0x6ec401744008f4B018Ed9A36f76e6629799Ee50E")
-
+func TestGetTokenBridgeContractAddress_UsesHardCodedMainnetContract(t *testing.T) {
 	c := newClient(log.NewNopLogger(), tokenbridgetypes.NewDepositReports(), tokenbridgetipstypes.NewDepositTips(), "tellor-1")
 	address, err := c.getTokenBridgeContractAddress()
 
@@ -96,7 +94,7 @@ func TestGetTokenBridgeContractAddress_UsesChainSpecificEnv(t *testing.T) {
 }
 
 func TestGetTokenBridgeContractAddress_UsesFallbackForCustomChain(t *testing.T) {
-	t.Setenv("TOKEN_BRIDGE_CONTRACT", "0x55355157703A44f7516FBB831333317E98944e32")
+	t.Setenv("TOKEN_BRIDGE_TEST_CONTRACT", "0x55355157703A44f7516FBB831333317E98944e32")
 
 	c := newClient(log.NewNopLogger(), tokenbridgetypes.NewDepositReports(), tokenbridgetipstypes.NewDepositTips(), "localnet")
 	address, err := c.getTokenBridgeContractAddress()


### PR DESCRIPTION
This PR updates API usage by generating a custom_query_config.toml that will work out of the box on tellor-1 and on layertest-5. 

What changed:
- Added env.example for easier setup
- Provided seperate environment variables for the correct mainnet and testnet bridge contract addresses.
- If a chain-id other than tellor-1 or layertest-5 is used, the daemon will fallback to the original "TOKEN_BRIDGE_CONTRACT" variable. (so set this for devnet / testing and leave the others alone)
- Added CGPRO_API_KEY environment variable handling for the auto-generated reporter configs.