### PR TITLE
Implement auto-balance feature for wallet management and bridging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -133,7 +133,7 @@ func init() {
 	// Auto-bridge: keep wallet at a fixed balance by bridging the excess to Ethereum
 	rootCmd.Flags().Uint64("auto-balance-to-keep", 0, "Keep this amount of loya in the wallet; bridge any excess to Ethereum at --auto-balance-execution-time (0 = disabled)")
 	rootCmd.Flags().String("auto-balance-execution-time", "00:00", "UTC time to execute the auto-balance bridge (HH:MM, e.g. '03:00')")
-	rootCmd.Flags().String("auto-balance-eth-addr", "", "Ethereum address to bridge excess tokens to (required when auto-balance-to-keep > 0)")
+	rootCmd.Flags().String("auto-balance-bridge-to-eth-addr", "", "Ethereum address to bridge excess tokens to (required when auto-balance-to-keep > 0)")
 
 	// Marking required flags
 	if err := rootCmd.MarkFlagRequired(flags.FlagHome); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tellor-io/layer-daemons/configs"
 	customquery "github.com/tellor-io/layer-daemons/custom_query"
 	daemonflags "github.com/tellor-io/layer-daemons/flags"
+
 	// need this for the address bech32 prefix config
 	_ "github.com/tellor-io/layer/app/config"
 
@@ -128,6 +129,11 @@ func init() {
 	rootCmd.Flags().Uint32("auto-unbonding-amount", 0, "Amount of tokens in loya to unbond each unbonding transaction (0 = disabled)")
 	rootCmd.Flags().String("auto-unbonding-max-stake-percentage", "0.0", "Maximum percentage of stake to unbond each unbonding transaction (0 = disabled, 1.0 = 100%). If unbonding amount exceeds this percentage, we will skip the unbonding transaction until it exceeds this percentage again.")
 	rootCmd.Flags().Duration("refresh-gas-estimates-interval", 12*time.Hour, "Interval for resetting cached gas estimates and gas-adjustment levels (<=0 disables)")
+
+	// Auto-bridge: keep wallet at a fixed balance by bridging the excess to Ethereum
+	rootCmd.Flags().Uint64("auto-balance-to-keep", 0, "Keep this amount of loya in the wallet; bridge any excess to Ethereum at --auto-balance-execution-time (0 = disabled)")
+	rootCmd.Flags().String("auto-balance-execution-time", "00:00", "UTC time to execute the auto-balance bridge (HH:MM, e.g. '03:00')")
+	rootCmd.Flags().String("auto-balance-eth-addr", "", "Ethereum address to bridge excess tokens to (required when auto-balance-to-keep > 0)")
 
 	// Marking required flags
 	if err := rootCmd.MarkFlagRequired(flags.FlagHome); err != nil {

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
 const defaultGas = uint64(240000)
@@ -57,6 +58,7 @@ type Client struct {
 	AccountName string
 	// Query clients
 	OracleQueryClient oracletypes.QueryClient
+	BankClient        banktypes.QueryClient
 
 	ReporterClient  reportertypes.QueryClient
 	CmtService      cmtservice.ServiceClient
@@ -155,6 +157,7 @@ func (c *Client) Start(
 
 	// Initialize the query clients. These are used to query the Cosmos gRPC query services.
 	c.OracleQueryClient = oracletypes.NewQueryClient(conn)
+	c.BankClient = banktypes.NewQueryClient(conn)
 	c.ReporterClient = reportertypes.NewQueryClient(conn)
 	c.GlobalfeeClient = globalfeetypes.NewQueryClient(conn)
 	c.CmtService = cmtservice.NewServiceClient(conn)
@@ -239,6 +242,23 @@ func (c *Client) Start(
 	} else {
 		c.logger.Info("Auto unbonding disabled")
 	}
+
+	// Read and validate auto-balance-to-keep configuration
+	autoBalanceToKeep := viper.GetUint64("auto-balance-to-keep")
+	autoBalanceEthAddr := strings.TrimPrefix(viper.GetString("auto-balance-eth-addr"), "0x")
+	if autoBalanceToKeep > 0 {
+		if autoBalanceEthAddr == "" {
+			return fmt.Errorf("auto-balance-eth-addr is required when auto-balance-to-keep > 0")
+		}
+		c.logger.Info("Auto balance-to-keep enabled",
+			"balance_to_keep_loya", autoBalanceToKeep,
+			"execution_time", viper.GetString("auto-balance-execution-time"),
+			"eth_addr", "0x"+autoBalanceEthAddr,
+		)
+	} else {
+		c.logger.Info("Auto balance-to-keep disabled")
+	}
+
 	if c.refreshGasEstimatesInterval > 0 {
 		c.logger.Info("Periodic gas estimate refresh enabled", "interval", c.refreshGasEstimatesInterval.String())
 	} else {
@@ -351,6 +371,9 @@ func StartReporterDaemonTaskLoop(
 
 	wg.Add(1)
 	go client.AutoUnbondStakePeriodically(ctx, wg)
+
+	wg.Add(1)
+	go client.AutoBridgeWalletExcessPeriodically(ctx, wg)
 
 	if client.refreshGasEstimatesInterval > 0 {
 		wg.Add(1)

--- a/reporter/client/reporter_monitors.go
+++ b/reporter/client/reporter_monitors.go
@@ -24,7 +24,9 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	bridgetypes "github.com/tellor-io/layer/x/bridge/types"
 )
 
 const (
@@ -304,6 +306,89 @@ func (c *Client) AutoUnbondStakePeriodically(ctx context.Context, wg *sync.WaitG
 			c.trySend(ctx, TxChannelInfo{Msg: unbondMsg, isBridge: false, NumRetries: 0, QueryMetaId: 0})
 
 		}
+	}
+}
+
+// AutoBridgeWalletExcessPeriodically watches the wallet balance once per day at the configured
+// UTC time. Whenever the balance exceeds --auto-balance-to-keep (loya), the excess (minus a
+// 1 TRB gas reserve) is bridged to the Ethereum address supplied by --auto-balance-eth-addr.
+func (c *Client) AutoBridgeWalletExcessPeriodically(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	balanceToKeep := viper.GetUint64("auto-balance-to-keep")
+	if balanceToKeep == 0 {
+		c.logger.Info("Auto balance-to-keep is disabled")
+		return
+	}
+
+	ethAddr := strings.TrimPrefix(viper.GetString("auto-balance-eth-addr"), "0x")
+	executionTime := viper.GetString("auto-balance-execution-time")
+
+	// Parse HH:MM
+	parts := strings.SplitN(executionTime, ":", 2)
+	if len(parts) != 2 {
+		c.logger.Error("invalid auto-balance-execution-time, expected HH:MM", "value", executionTime)
+		return
+	}
+	hour, errH := strconv.Atoi(parts[0])
+	minute, errM := strconv.Atoi(parts[1])
+	if errH != nil || errM != nil || hour < 0 || hour > 23 || minute < 0 || minute > 59 {
+		c.logger.Error("invalid auto-balance-execution-time value", "value", executionTime)
+		return
+	}
+
+	for {
+		now := time.Now().UTC()
+		next := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, time.UTC)
+		if !now.Before(next) {
+			next = next.Add(24 * time.Hour)
+		}
+
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Auto balance-to-keep stopped")
+			return
+		case <-time.After(time.Until(next)):
+		}
+
+		c.logger.Info("Auto balance-to-keep: checking wallet balance")
+
+		balResp, err := c.BankClient.Balance(ctx, &banktypes.QueryBalanceRequest{
+			Address: c.accAddr.String(),
+			Denom:   "loya",
+		})
+		if err != nil {
+			c.logger.Error("auto balance-to-keep: failed to query wallet balance", "error", err)
+			continue
+		}
+
+		walletBal := balResp.Balance.Amount
+		keepAmt := math.NewIntFromUint64(balanceToKeep)
+		// Reserve 1 TRB (1_000_000 loya) for future gas so the wallet can keep operating.
+		gasReserve := math.NewInt(1_000_000)
+		amountToBridge := walletBal.Sub(keepAmt).Sub(gasReserve)
+
+		if !amountToBridge.IsPositive() {
+			c.logger.Info("auto balance-to-keep: wallet below threshold, nothing to bridge",
+				"wallet_loya", walletBal.String(),
+				"keep_loya", keepAmt.String(),
+			)
+			continue
+		}
+
+		c.logger.Info("auto balance-to-keep: bridging excess",
+			"wallet_loya", walletBal.String(),
+			"keep_loya", keepAmt.String(),
+			"bridge_amount_loya", amountToBridge.String(),
+			"destination", "0x"+ethAddr,
+		)
+
+		msg := &bridgetypes.MsgWithdrawTokens{
+			Creator:   c.accAddr.String(),
+			Recipient: ethAddr,
+			Amount:    sdk.NewCoin("loya", amountToBridge),
+		}
+		c.txChan <- TxChannelInfo{Msg: msg, isBridge: true, NumRetries: 0, QueryMetaId: 0}
 	}
 }
 


### PR DESCRIPTION
Adds a new goroutine `AutoBridgeWalletExcessPeriodically` that runs daily at a configured UTC time. When the wallet balance exceeds `--auto-balance-to-keep` (loya), the excess minus a 1 TRB gas reserve is bridged to Ethereum via `--auto-balance-eth-addr`.

New flags:
- `--auto-balance-to-keep`  loya balance to maintain (0 = disabled)
- `--auto-balance-execution-time` UTC HH:MM to run the check (default: `00:00`)
- `--auto-balance-eth-addr` Ethereum destination address (required when feature enabled)
