### PR TITLE
Add PriceGuard skipped metric and periodic balance monitor

### DIFF
--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -58,7 +58,6 @@ type Client struct {
 	AccountName string
 	// Query clients
 	OracleQueryClient oracletypes.QueryClient
-	BankClient        banktypes.QueryClient
 
 	ReporterClient  reportertypes.QueryClient
 	CmtService      cmtservice.ServiceClient
@@ -159,7 +158,6 @@ func (c *Client) Start(
 	// Initialize the query clients. These are used to query the Cosmos gRPC query services.
 	c.OracleQueryClient = oracletypes.NewQueryClient(conn)
 	c.BankClient = banktypes.NewQueryClient(conn)
-	c.ReporterClient = reportertypes.NewQueryClient(conn)
 	c.GlobalfeeClient = globalfeetypes.NewQueryClient(conn)
 	c.CmtService = cmtservice.NewServiceClient(conn)
 	c.AuthClient = authtypes.NewQueryClient(conn)

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -157,6 +157,7 @@ func (c *Client) Start(
 
 	// Initialize the query clients. These are used to query the Cosmos gRPC query services.
 	c.OracleQueryClient = oracletypes.NewQueryClient(conn)
+	c.ReporterClient = reportertypes.NewQueryClient(conn)
 	c.GlobalfeeClient = globalfeetypes.NewQueryClient(conn)
 	c.CmtService = cmtservice.NewServiceClient(conn)
 	c.AuthClient = authtypes.NewQueryClient(conn)

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
 const defaultGas = uint64(240000)

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -157,7 +157,6 @@ func (c *Client) Start(
 
 	// Initialize the query clients. These are used to query the Cosmos gRPC query services.
 	c.OracleQueryClient = oracletypes.NewQueryClient(conn)
-	c.BankClient = banktypes.NewQueryClient(conn)
 	c.GlobalfeeClient = globalfeetypes.NewQueryClient(conn)
 	c.CmtService = cmtservice.NewServiceClient(conn)
 	c.AuthClient = authtypes.NewQueryClient(conn)

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -32,7 +32,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 const defaultGas = uint64(240000)
@@ -60,7 +59,6 @@ type Client struct {
 	// Query clients
 	OracleQueryClient oracletypes.QueryClient
 	BankClient        banktypes.QueryClient
-	StakingClient     stakingtypes.QueryClient
 
 	ReporterClient  reportertypes.QueryClient
 	CmtService      cmtservice.ServiceClient
@@ -161,7 +159,6 @@ func (c *Client) Start(
 	// Initialize the query clients. These are used to query the Cosmos gRPC query services.
 	c.OracleQueryClient = oracletypes.NewQueryClient(conn)
 	c.BankClient = banktypes.NewQueryClient(conn)
-	c.StakingClient = stakingtypes.NewQueryClient(conn)
 	c.ReporterClient = reportertypes.NewQueryClient(conn)
 	c.GlobalfeeClient = globalfeetypes.NewQueryClient(conn)
 	c.CmtService = cmtservice.NewServiceClient(conn)
@@ -358,9 +355,6 @@ func StartReporterDaemonTaskLoop(
 
 	wg.Add(1)
 	go client.AutoUnbondStakePeriodically(ctx, wg)
-
-	wg.Add(1)
-	go client.MonitorBalancePeriodically(ctx, wg)
 
 	if client.refreshGasEstimatesInterval > 0 {
 		wg.Add(1)

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -31,6 +31,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 const defaultGas = uint64(240000)
@@ -57,6 +59,8 @@ type Client struct {
 	AccountName string
 	// Query clients
 	OracleQueryClient oracletypes.QueryClient
+	BankClient        banktypes.QueryClient
+	StakingClient     stakingtypes.QueryClient
 
 	ReporterClient  reportertypes.QueryClient
 	CmtService      cmtservice.ServiceClient
@@ -136,6 +140,7 @@ func (c *Client) Start(
 	)
 
 	c.MarketParams = marketParams
+	RegisterPriceGuardMarketParams(marketParams)
 	c.MarketToExchange = marketToExchange
 
 	c.TokenDepositsCache = tokenDepositsCache
@@ -155,6 +160,8 @@ func (c *Client) Start(
 
 	// Initialize the query clients. These are used to query the Cosmos gRPC query services.
 	c.OracleQueryClient = oracletypes.NewQueryClient(conn)
+	c.BankClient = banktypes.NewQueryClient(conn)
+	c.StakingClient = stakingtypes.NewQueryClient(conn)
 	c.ReporterClient = reportertypes.NewQueryClient(conn)
 	c.GlobalfeeClient = globalfeetypes.NewQueryClient(conn)
 	c.CmtService = cmtservice.NewServiceClient(conn)
@@ -351,6 +358,9 @@ func StartReporterDaemonTaskLoop(
 
 	wg.Add(1)
 	go client.AutoUnbondStakePeriodically(ctx, wg)
+
+	wg.Add(1)
+	go client.MonitorBalancePeriodically(ctx, wg)
 
 	if client.refreshGasEstimatesInterval > 0 {
 		wg.Add(1)

--- a/reporter/client/price_guard.go
+++ b/reporter/client/price_guard.go
@@ -112,6 +112,7 @@ func (pg *PriceGuard) ShouldSubmit(queryData []byte, newPrice float64) (bool, st
 			"lastPrice", lastPrice,
 			"newPrice", newPrice,
 		)
+		emitPriceGuardSkippedMetric(queryData, change*100, ReasonDeviation)
 		return false, reason
 	}
 

--- a/reporter/client/price_guard_metrics.go
+++ b/reporter/client/price_guard_metrics.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"encoding/hex"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/tellor-io/layer-daemons/lib/metrics"
+	"github.com/tellor-io/layer/utils"
+)
+
+// Metric labels for price guard.
+const (
+	LabelPair      = "pair"
+	LabelDeviation = "deviation"
+	LabelReason    = "reason"
+)
+
+// Block reasons for price guard.
+const (
+	ReasonDeviation = "deviation"
+	ReasonExpired   = "expired"
+)
+
+var (
+	priceGuardPairRegistry = make(map[string]string) // queryDataHex -> pair
+	priceGuardRegistryMu   sync.RWMutex
+)
+
+// RegisterPriceGuardMarketParams registers market params for pair label lookup in metrics.
+// Accepts any slice of structs with QueryData and Pair string fields.
+func RegisterPriceGuardMarketParams(params any) {
+	priceGuardRegistryMu.Lock()
+	defer priceGuardRegistryMu.Unlock()
+
+	priceGuardPairRegistry = make(map[string]string)
+	v := reflect.ValueOf(params)
+	if v.Kind() != reflect.Slice {
+		return
+	}
+	for i := 0; i < v.Len(); i++ {
+		item := v.Index(i)
+		if item.Kind() == reflect.Ptr {
+			item = item.Elem()
+		}
+		qd := item.FieldByName("QueryData")
+		pair := item.FieldByName("Pair")
+		if qd.IsValid() && pair.IsValid() {
+			priceGuardPairRegistry[strings.ToLower(qd.String())] = pair.String()
+		}
+	}
+}
+
+func getPriceGuardPair(queryDataHex string) string {
+	priceGuardRegistryMu.RLock()
+	defer priceGuardRegistryMu.RUnlock()
+	return priceGuardPairRegistry[strings.ToLower(queryDataHex)]
+}
+
+// emitPriceGuardSkippedMetric emits a counter metric each time a report is
+// skipped by the price guard. reason should be one of ReasonDeviation or ReasonExpired.
+func emitPriceGuardSkippedMetric(queryData []byte, deviationPercent float64, reason string) {
+	queryIDBytes := utils.QueryIDFromData(queryData)
+	queryDataStr := hex.EncodeToString(queryData)
+
+	pair := getPriceGuardPair(queryDataStr)
+	pairLabel := pair
+	if pairLabel == "" {
+		pairLabel = fmt.Sprintf("%x", queryIDBytes)
+	}
+
+	metrics.IncrCounterWithLabels(
+		"daemon_report_skipped",
+		1,
+		metrics.Label{Name: LabelPair, Value: pairLabel},
+		metrics.Label{Name: LabelDeviation, Value: fmt.Sprintf("%.2f%%", deviationPercent)},
+		metrics.Label{Name: LabelReason, Value: reason},
+	)
+}

--- a/reporter/client/reporter_monitors.go
+++ b/reporter/client/reporter_monitors.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 	"github.com/spf13/viper"
 	tokenbridgetipstypes "github.com/tellor-io/layer-daemons/server/types/token_bridge_tips"
+	"github.com/tellor-io/layer-daemons/lib/metrics"
 	"github.com/tellor-io/layer/utils"
 	oracletypes "github.com/tellor-io/layer/x/oracle/types"
 	reportertypes "github.com/tellor-io/layer/x/reporter/types"
@@ -24,6 +25,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -304,6 +306,75 @@ func (c *Client) AutoUnbondStakePeriodically(ctx context.Context, wg *sync.WaitG
 			c.trySend(ctx, TxChannelInfo{Msg: unbondMsg, isBridge: false, NumRetries: 0, QueryMetaId: 0})
 
 		}
+	}
+}
+
+const balanceMonitorInterval = 30 * time.Second
+
+// MonitorBalancePeriodically queries wallet and staking balances every 30 seconds
+// and emits telemetry metrics so operators can alert on low balances.
+func (c *Client) MonitorBalancePeriodically(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	c.logger.Info("Balance monitor started", "interval", balanceMonitorInterval)
+
+	// Query immediately on startup, then tick every 30 seconds.
+	c.updateBalanceMetrics(ctx)
+
+	ticker := time.NewTicker(balanceMonitorInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Balance monitor stopped")
+			return
+		case <-ticker.C:
+			c.updateBalanceMetrics(ctx)
+		}
+	}
+}
+
+// updateBalanceMetrics queries balances and emits telemetry gauges.
+func (c *Client) updateBalanceMetrics(ctx context.Context) {
+	qCtx, cancel := context.WithTimeout(ctx, defaultQueryTimeout)
+	defer cancel()
+
+	// Wallet balance
+	balResp, err := c.BankClient.Balance(qCtx, &banktypes.QueryBalanceRequest{
+		Address: c.accAddr.String(),
+		Denom:   "loya",
+	})
+	if err != nil {
+		c.logger.Error("balance monitor: failed to query wallet balance", "error", err)
+	} else {
+		walletLoya := balResp.Balance.Amount.Int64()
+		metrics.SetGaugeWithLabels("daemon_wallet_balance_loya",
+			float32(walletLoya),
+			metrics.Label{Name: "address", Value: c.accAddr.String()},
+		)
+		c.logger.Debug("balance monitor: wallet balance", "loya", walletLoya)
+	}
+
+	// Staking (delegated) balance
+	delResp, err := c.StakingClient.DelegatorDelegations(qCtx, &stakingtypes.QueryDelegatorDelegationsRequest{
+		DelegatorAddr: c.accAddr.String(),
+		Pagination:    &query.PageRequest{Limit: 100},
+	})
+	if err != nil {
+		c.logger.Error("balance monitor: failed to query staking delegations", "error", err)
+	} else {
+		var stakingLoya int64
+		for _, del := range delResp.DelegationResponses {
+			if !del.Balance.Amount.IsNil() {
+				stakingLoya += del.Balance.Amount.Int64()
+			}
+		}
+		metrics.SetGaugeWithLabels("daemon_staking_balance_loya",
+			float32(stakingLoya),
+			metrics.Label{Name: "address", Value: c.accAddr.String()},
+		)
+		c.logger.Debug("balance monitor: staking balance", "loya", stakingLoya)
 	}
 }
 

--- a/reporter/client/reporter_monitors.go
+++ b/reporter/client/reporter_monitors.go
@@ -16,7 +16,6 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 	"github.com/spf13/viper"
 	tokenbridgetipstypes "github.com/tellor-io/layer-daemons/server/types/token_bridge_tips"
-	"github.com/tellor-io/layer-daemons/lib/metrics"
 	"github.com/tellor-io/layer/utils"
 	oracletypes "github.com/tellor-io/layer/x/oracle/types"
 	reportertypes "github.com/tellor-io/layer/x/reporter/types"
@@ -25,7 +24,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -306,75 +304,6 @@ func (c *Client) AutoUnbondStakePeriodically(ctx context.Context, wg *sync.WaitG
 			c.trySend(ctx, TxChannelInfo{Msg: unbondMsg, isBridge: false, NumRetries: 0, QueryMetaId: 0})
 
 		}
-	}
-}
-
-const balanceMonitorInterval = 30 * time.Second
-
-// MonitorBalancePeriodically queries wallet and staking balances every 30 seconds
-// and emits telemetry metrics so operators can alert on low balances.
-func (c *Client) MonitorBalancePeriodically(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	c.logger.Info("Balance monitor started", "interval", balanceMonitorInterval)
-
-	// Query immediately on startup, then tick every 30 seconds.
-	c.updateBalanceMetrics(ctx)
-
-	ticker := time.NewTicker(balanceMonitorInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			c.logger.Info("Balance monitor stopped")
-			return
-		case <-ticker.C:
-			c.updateBalanceMetrics(ctx)
-		}
-	}
-}
-
-// updateBalanceMetrics queries balances and emits telemetry gauges.
-func (c *Client) updateBalanceMetrics(ctx context.Context) {
-	qCtx, cancel := context.WithTimeout(ctx, defaultQueryTimeout)
-	defer cancel()
-
-	// Wallet balance
-	balResp, err := c.BankClient.Balance(qCtx, &banktypes.QueryBalanceRequest{
-		Address: c.accAddr.String(),
-		Denom:   "loya",
-	})
-	if err != nil {
-		c.logger.Error("balance monitor: failed to query wallet balance", "error", err)
-	} else {
-		walletLoya := balResp.Balance.Amount.Int64()
-		metrics.SetGaugeWithLabels("daemon_wallet_balance_loya",
-			float32(walletLoya),
-			metrics.Label{Name: "address", Value: c.accAddr.String()},
-		)
-		c.logger.Debug("balance monitor: wallet balance", "loya", walletLoya)
-	}
-
-	// Staking (delegated) balance
-	delResp, err := c.StakingClient.DelegatorDelegations(qCtx, &stakingtypes.QueryDelegatorDelegationsRequest{
-		DelegatorAddr: c.accAddr.String(),
-		Pagination:    &query.PageRequest{Limit: 100},
-	})
-	if err != nil {
-		c.logger.Error("balance monitor: failed to query staking delegations", "error", err)
-	} else {
-		var stakingLoya int64
-		for _, del := range delResp.DelegationResponses {
-			if !del.Balance.Amount.IsNil() {
-				stakingLoya += del.Balance.Amount.Int64()
-			}
-		}
-		metrics.SetGaugeWithLabels("daemon_staking_balance_loya",
-			float32(stakingLoya),
-			metrics.Label{Name: "address", Value: c.accAddr.String()},
-		)
-		c.logger.Debug("balance monitor: staking balance", "loya", stakingLoya)
 	}
 }
 


### PR DESCRIPTION
Adds two observability improvements:

1. `daemon_report_skipped` counter (labels: `pair`, `deviation`, `reason`) emitted each time the price guard blocks a submission.
2. `MonitorBalancePeriodically` goroutine that queries wallet and staking balances every 30s and emits `daemon_wallet_balance_loya` / `daemon_staking_balance_loya` gauges.

Both follow the existing `telemetry` pattern already used in the codebase.