### PR TITLE
expanded grpc and rpc fallback features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,34 @@
 
 **Note:** Daemon services code was adopted from dydx [](https://github.com/dydxprotocol/v4-chain/tree/main/protocol/daemons) and reconfigured.
 
+## Configuration
+
+The daemon loads environment variables from the current directory's `.env` file, or from `../.env` when run from a subdirectory. See [`env.example`](./env.example) for a complete starting point.
+
+Layer endpoint configuration can be provided with comma-separated environment variables:
+
+```sh
+RPC_NODES=http://node_endpoint1:26657,http://node_endpoint2:26657
+GRPC_NODES=127.0.0.1:9090,node2:9090
+```
+
+The first endpoint in each list is treated as the primary endpoint. Later entries are used as ordered fallbacks.
+
+Endpoint env vars take precedence over the existing CLI flags:
+
+- `RPC_NODES` is preferred over `--node`.
+- `GRPC_NODES` is preferred over `--grpc`.
+- If an env var is unset, the daemon preserves the old behavior by using the matching flag value as a single endpoint.
+
+At startup, the daemon checks the configured gRPC and CometBFT RPC endpoints for a matching chain ID and starts with the first healthy matching endpoints. The reporter keeps the CometBFT RPC endpoint list and falls back to later RPC nodes for network/client failures during status checks, transaction lookup, and transaction broadcast. It does not switch endpoints for semantic chain failures such as out-of-gas responses, non-zero tx result codes, or normal tx-not-found polling.
+
+There is no shared API endpoint env var for this daemon. Third-party API configuration is handled by the pricefeed and custom query config files, while token bridge Ethereum RPC configuration currently uses `ETH_RPC_URL_PRIMARY` and `ETH_RPC_URL_FALLBACK`.
+
 ## Task loops
 
 ## PriceFetcher
 
-- Will query exchanges for prices once or multiple times based on wether the api supports single vs multi markets; ie wether an api needs to be queried for each pair individually or can return multiple pairs at once, [See here for exchange details](./constants/static_exchange_details.go).
+- Will query exchanges for prices once or multiple times based on whether the API supports single vs multi markets; i.e. whether an API needs to be queried for each pair individually or can return multiple pairs at once. [See here for exchange details](./constants/static_exchange_details.go).
 
 ## PriceEncoder
 
@@ -63,7 +86,7 @@ type MarketParam struct {
     // A string of json that encodes the configuration for resolving the price
     // of this market on various exchanges.
     ExchangeConfigJson string
-    // Query data is the market pair represention in layer
+    // Query data is the market pair representation in layer
     QueryData string
 }
 ```

--- a/app.go
+++ b/app.go
@@ -46,8 +46,9 @@ type App struct {
 func NewApp(
 	ctx context.Context,
 	logger log.Logger,
-	chainId,
-	grpcAddress,
+	chainId string,
+	grpcEndpoints []string,
+	rpcEndpoints []string,
 	homePath string,
 	prometheusPort int,
 ) *App {
@@ -140,7 +141,7 @@ func NewApp(
 		// Use cancellable context instead of context.Background
 		ctx,
 		daemonFlags,
-		grpcAddress,
+		grpcEndpoints[0],
 		logger,
 		&daemontypes.GrpcClientImpl{},
 		marketParamsConfig,
@@ -161,7 +162,7 @@ func NewApp(
 			// Use cancellable context instead of context.Background
 			ctx,
 			daemonFlags,
-			grpcAddress,
+			grpcEndpoints,
 			&daemontypes.GrpcClientImpl{},
 			marketParamsConfig,
 			indexPriceCache,
@@ -169,6 +170,7 @@ func NewApp(
 			tokenBridgeTipsCache,
 			queries,
 			chainId,
+			rpcEndpoints,
 		); err != nil {
 			logger.Error("Reporter client failed to start", "error", err)
 		}

--- a/cmd/chain_id.go
+++ b/cmd/chain_id.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
@@ -12,29 +13,65 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 )
 
-// detectChainID queries both the gRPC endpoint and the CometBFT RPC endpoint
-// for the chain ID, validates that they agree, and returns the chain ID.
-// Returns an error if either endpoint is unreachable or if they return
-// different chain IDs.
-func detectChainID(ctx context.Context, grpcAddr, nodeRPCAddr string) (string, error) {
+type detectedEndpointChainID struct {
+	endpoint string
+	chainID  string
+}
+
+type chainIDDetector func(context.Context, string) (string, error)
+
+func detectChainIDFromEndpoints(ctx context.Context, grpcAddrs, nodeRPCAddrs []string) (string, string, string, error) {
 	detectCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	grpcChainID, err := chainIDFromGRPC(detectCtx, grpcAddr)
+	grpcChainIDs, err := detectEndpointChainIDs(detectCtx, "gRPC", grpcAddrs, chainIDFromGRPC)
 	if err != nil {
-		return "", fmt.Errorf("failed to detect chain ID via gRPC (%s): %w", grpcAddr, err)
+		return "", "", "", err
 	}
 
-	rpcChainID, err := chainIDFromRPC(detectCtx, nodeRPCAddr)
+	rpcChainIDs, err := detectEndpointChainIDs(detectCtx, "node RPC", nodeRPCAddrs, chainIDFromRPC)
 	if err != nil {
-		return "", fmt.Errorf("failed to detect chain ID via node RPC (%s): %w", nodeRPCAddr, err)
+		return "", "", "", err
 	}
 
-	if grpcChainID != rpcChainID {
-		return "", fmt.Errorf("chain ID mismatch: gRPC returned %q, node RPC returned %q", grpcChainID, rpcChainID)
+	if err := validateReachableChainIDs("gRPC", grpcChainIDs); err != nil {
+		return "", "", "", err
+	}
+	if err := validateReachableChainIDs("node RPC", rpcChainIDs); err != nil {
+		return "", "", "", err
+	}
+	if grpcChainIDs[0].chainID != rpcChainIDs[0].chainID {
+		return "", "", "", fmt.Errorf("chain ID mismatch: gRPC returned %q, node RPC returned %q", grpcChainIDs[0].chainID, rpcChainIDs[0].chainID)
 	}
 
-	return grpcChainID, nil
+	return grpcChainIDs[0].chainID, grpcChainIDs[0].endpoint, rpcChainIDs[0].endpoint, nil
+}
+
+func detectEndpointChainIDs(ctx context.Context, endpointType string, endpoints []string, detector chainIDDetector) ([]detectedEndpointChainID, error) {
+	var detected []detectedEndpointChainID
+	var errs []string
+	for _, endpoint := range endpoints {
+		chainID, err := detector(ctx, endpoint)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", endpoint, err))
+			continue
+		}
+		detected = append(detected, detectedEndpointChainID{endpoint: endpoint, chainID: chainID})
+	}
+	if len(detected) == 0 {
+		return nil, fmt.Errorf("failed to detect chain ID via any %s endpoint: %s", endpointType, strings.Join(errs, "; "))
+	}
+	return detected, nil
+}
+
+func validateReachableChainIDs(endpointType string, detected []detectedEndpointChainID) error {
+	expected := detected[0].chainID
+	for _, item := range detected[1:] {
+		if item.chainID != expected {
+			return fmt.Errorf("%s endpoints disagree on chain ID: %s returned %q, %s returned %q", endpointType, detected[0].endpoint, expected, item.endpoint, item.chainID)
+		}
+	}
+	return nil
 }
 
 func chainIDFromGRPC(ctx context.Context, grpcAddr string) (string, error) {

--- a/cmd/chain_id_test.go
+++ b/cmd/chain_id_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateReachableChainIDsAllowsMatchingEndpoints(t *testing.T) {
+	err := validateReachableChainIDs("gRPC", []detectedEndpointChainID{
+		{endpoint: "node1:9090", chainID: "tellor-1"},
+		{endpoint: "node2:9090", chainID: "tellor-1"},
+	})
+	require.NoError(t, err)
+}
+
+func TestValidateReachableChainIDsRejectsMismatchedEndpoints(t *testing.T) {
+	err := validateReachableChainIDs("node RPC", []detectedEndpointChainID{
+		{endpoint: "http://node1:26657", chainID: "tellor-1"},
+		{endpoint: "http://node2:26657", chainID: "layertest-5"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "disagree on chain ID")
+}

--- a/cmd/endpoints.go
+++ b/cmd/endpoints.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	envRPCNodes  = "RPC_NODES"
+	envGRPCNodes = "GRPC_NODES"
+)
+
+type endpointListConfig struct {
+	Endpoints []string
+	Source    string
+}
+
+func parseGRPCEndpoints(value string) ([]string, error) {
+	return parseEndpointValues(value)
+}
+
+func parseRPCEndpoints(value string) ([]string, error) {
+	return parseEndpointValues(value)
+}
+
+func parseEndpointValues(value string) ([]string, error) {
+	parts := strings.Split(value, ",")
+	endpoints := make([]string, 0, len(parts))
+	for _, part := range parts {
+		endpoint := strings.TrimSpace(part)
+		if endpoint == "" {
+			return nil, fmt.Errorf("endpoint list contains an empty entry")
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+	return endpoints, nil
+}
+
+func endpointsFromEnvOrFlag(envName, flagName, flagValue string) (endpointListConfig, error) {
+	if envValue, ok := os.LookupEnv(envName); ok {
+		endpoints, err := parseEndpointValues(envValue)
+		if err != nil {
+			return endpointListConfig{}, fmt.Errorf("%s: %w", envName, err)
+		}
+		return endpointListConfig{Endpoints: endpoints, Source: envName}, nil
+	}
+
+	endpoints, err := parseEndpointValues(flagValue)
+	if err != nil {
+		return endpointListConfig{}, fmt.Errorf("--%s: %w", flagName, err)
+	}
+	return endpointListConfig{Endpoints: endpoints, Source: "--" + flagName}, nil
+}
+
+func grpcEndpointsFromEnvOrFlag(flagValue string) (endpointListConfig, error) {
+	return endpointsFromEnvOrFlag(envGRPCNodes, "grpc", flagValue)
+}
+
+func rpcEndpointsFromEnvOrFlag(flagValue string) (endpointListConfig, error) {
+	return endpointsFromEnvOrFlag(envRPCNodes, "node", flagValue)
+}
+
+func moveEndpointToFront(endpoints []string, selected string) []string {
+	reordered := append([]string(nil), endpoints...)
+	for i, endpoint := range reordered {
+		if endpoint != selected {
+			continue
+		}
+		copy(reordered[1:i+1], reordered[0:i])
+		reordered[0] = selected
+		return reordered
+	}
+	return reordered
+}

--- a/cmd/endpoints_test.go
+++ b/cmd/endpoints_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGRPCEndpoints(t *testing.T) {
+	endpoints, err := parseGRPCEndpoints(" node1:9090,node2:9090 ")
+	require.NoError(t, err)
+	require.Equal(t, []string{"node1:9090", "node2:9090"}, endpoints)
+}
+
+func TestParseRPCEndpoints(t *testing.T) {
+	endpoints, err := parseRPCEndpoints(" https://node1:26657,https://node2:26657 ")
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://node1:26657", "https://node2:26657"}, endpoints)
+}
+
+func TestParseGRPCEndpointsRejectsEmptyEntries(t *testing.T) {
+	_, err := parseGRPCEndpoints("node1,,node2")
+	require.Error(t, err)
+
+	_, err = parseGRPCEndpoints(" ")
+	require.Error(t, err)
+}
+
+func TestRPCEndpointsFromEnvOrFlagPrefersEnv(t *testing.T) {
+	t.Setenv(envRPCNodes, "env-node1,env-node2")
+
+	cfg, err := rpcEndpointsFromEnvOrFlag("flag-node")
+	require.NoError(t, err)
+	require.Equal(t, envRPCNodes, cfg.Source)
+	require.Equal(t, []string{"env-node1", "env-node2"}, cfg.Endpoints)
+}
+
+func TestGRPCEndpointsFromEnvOrFlagFallsBackToFlag(t *testing.T) {
+	cfg, err := grpcEndpointsFromEnvOrFlag("flag-node")
+	require.NoError(t, err)
+	require.Equal(t, "--grpc", cfg.Source)
+	require.Equal(t, []string{"flag-node"}, cfg.Endpoints)
+}
+
+func TestMoveEndpointToFront(t *testing.T) {
+	endpoints := []string{"node1", "node2", "node3"}
+
+	reordered := moveEndpointToFront(endpoints, "node2")
+
+	require.Equal(t, []string{"node2", "node1", "node3"}, reordered)
+	require.Equal(t, []string{"node1", "node2", "node3"}, endpoints)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,20 +57,28 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Normal daemon mode - validate required flags
-		grpcAddr := viper.GetString(flags.FlagGRPC)
+		grpcCfg, err := grpcEndpointsFromEnvOrFlag(viper.GetString(flags.FlagGRPC))
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
 		from := viper.GetString(flags.FlagFrom)
-		node := viper.GetString(flags.FlagNode)
+		rpcCfg, err := rpcEndpointsFromEnvOrFlag(viper.GetString(flags.FlagNode))
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
 
-		if grpcAddr == "" {
-			fmt.Printf("Error: --grpc is required in reporter mode\n")
+		if len(grpcCfg.Endpoints) == 0 {
+			fmt.Printf("Error: %s or --%s is required in reporter mode\n", envGRPCNodes, flags.FlagGRPC)
 			os.Exit(1)
 		}
 		if from == "" {
 			fmt.Printf("Error: --from is required in reporter mode\n")
 			os.Exit(1)
 		}
-		if node == "" {
-			fmt.Printf("Error: --node is required in reporter mode\n")
+		if len(rpcCfg.Endpoints) == 0 {
+			fmt.Printf("Error: %s or --%s is required in reporter mode\n", envRPCNodes, flags.FlagNode)
 			os.Exit(1)
 		}
 
@@ -78,15 +86,30 @@ var rootCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer stop()
 
-		chainId, err := detectChainID(ctx, grpcAddr, node)
+		chainId, grpcAddr, selectedRPCNode, err := detectChainIDFromEndpoints(ctx, grpcCfg.Endpoints, rpcCfg.Endpoints)
 		if err != nil {
 			fmt.Printf("Error: could not detect chain ID: %v\n", err)
 			os.Exit(1)
 		}
-		logger.Info("Detected chain ID", "chain_id", chainId)
+		logger.Info(
+			"Detected chain ID",
+			"chain_id", chainId,
+			"grpc_endpoint", grpcAddr,
+			"grpc_source", grpcCfg.Source,
+			"rpc_endpoint", selectedRPCNode,
+			"rpc_source", rpcCfg.Source,
+		)
 
 		// Pass prometheusPort and signal context to NewApp
-		appInstance := daemons.NewApp(ctx, logger, chainId, grpcAddr, homePath, prometheusPort)
+		appInstance := daemons.NewApp(
+			ctx,
+			logger,
+			chainId,
+			moveEndpointToFront(grpcCfg.Endpoints, grpcAddr),
+			moveEndpointToFront(rpcCfg.Endpoints, selectedRPCNode),
+			homePath,
+			prometheusPort,
+		)
 
 		// Wait for signal
 		<-ctx.Done()

--- a/env.example
+++ b/env.example
@@ -6,6 +6,12 @@
 ETH_RPC_URL_PRIMARY=https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY
 ETH_RPC_URL_FALLBACK=https://eth-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_API_KEY
 
+# Layer endpoints
+# RPC_NODES and GRPC_NODES are comma-separated. The first endpoint is primary;
+# later endpoints are used as ordered fallbacks.
+RPC_NODES=http://node_endpoint1:26657,http://node_endpoint2:26657
+GRPC_NODES=node1:9090,node2:9090
+
 # Token bridge contracts are hard-coded for tellor-1 and layertest-5.
 
 # Optional fallback for local/custom chains.

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/viper"
 	globalfeetypes "github.com/strangelove-ventures/globalfee/x/globalfee/types"
@@ -36,7 +35,11 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
-const defaultGas = uint64(240000)
+const (
+	defaultGas                   = uint64(240000)
+	primaryEndpointCheckInterval = 5 * time.Minute
+	primaryEndpointProbeTimeout  = 10 * time.Second
+)
 
 var (
 	commitedIds   = make(map[uint64]bool)
@@ -85,8 +88,12 @@ type Client struct {
 	gasEstimator                *gasEstimateState
 
 	// Resources that need cleanup
+	grpcMu      sync.RWMutex
 	grpcConn    *grpc.ClientConn
 	grpcClient  daemontypes.GrpcClient
+	grpcManager *grpcEndpointManager
+	rpcManager  *rpcEndpointManager
+
 	wg          sync.WaitGroup
 	broadcastWg sync.WaitGroup // Tracks goroutines in BroadcastTxMsgToChain
 	stopOnce    sync.Once
@@ -125,7 +132,7 @@ func NewClient(logger log.Logger, valGasMin string) *Client {
 func (c *Client) Start(
 	ctx context.Context,
 	flags daemonflags.DaemonFlags,
-	grpcAddress string,
+	grpcEndpoints []string,
 	grpcClient daemontypes.GrpcClient,
 	marketParams []pricefeedtypes.MarketParam,
 	marketToExchange *pricefeedservertypes.MarketToExchangePrices,
@@ -133,6 +140,7 @@ func (c *Client) Start(
 	tokenBridgeTipsCache *tokenbridgetipstypes.DepositTips,
 	custom_queries map[string]customquery.QueryConfig,
 	chainId string,
+	rpcEndpoints []string,
 ) error {
 	// Log the daemon flags.
 	c.logger.Info(
@@ -146,30 +154,20 @@ func (c *Client) Start(
 	c.TokenDepositsCache = tokenDepositsCache
 	c.TokenBridgeTipsCache = tokenBridgeTipsCache
 	c.Custom_query = custom_queries
-	// Make a connection to the Cosmos gRPC query services.
-	c.logger.Info("Establishing gRPC connection", "address", grpcAddress)
-	conn, err := grpcClient.NewTcpConnection(ctx, grpcAddress)
+	grpcManager, err := newGRPCEndpointManager(grpcEndpoints, c.logger, grpcClient)
 	if err != nil {
-		c.logger.Error("Failed to establish gRPC connection to Cosmos gRPC query services", "error", err, "address", grpcAddress)
-		return err
+		return fmt.Errorf("failed to initialize gRPC endpoint manager: %w", err)
 	}
-	c.logger.Info("gRPC connection established successfully", "address", grpcAddress)
-	// Store connection and grpcClient for cleanup
-	c.grpcConn = conn
+	c.grpcManager = grpcManager
 	c.grpcClient = grpcClient
 
-	// Initialize the query clients. These are used to query the Cosmos gRPC query services.
-	c.OracleQueryClient = oracletypes.NewQueryClient(conn)
-	c.BankClient = banktypes.NewQueryClient(conn)
-	c.ReporterClient = reportertypes.NewQueryClient(conn)
-	c.GlobalfeeClient = globalfeetypes.NewQueryClient(conn)
-	c.CmtService = cmtservice.NewServiceClient(conn)
-	c.AuthClient = authtypes.NewQueryClient(conn)
+	if err := c.connectInitialGRPCEndpoint(ctx); err != nil {
+		return err
+	}
 
 	keyName := viper.GetString("from")
 	homeDir := viper.GetString("home")
 	brdcstMode := viper.GetString("broadcast-mode")
-	nodeUri := viper.GetString("node")
 	kb := viper.GetString("keyring-backend")
 
 	// Read price guard config
@@ -230,7 +228,8 @@ func (c *Client) Start(
 
 	// Log price guard configuration
 	if priceGuardEnabled {
-		c.logger.Info("Price guard enabled",
+		c.logger.Info(
+			"Price guard enabled",
 			"threshold", fmt.Sprintf("%.5f%%", priceGuardThreshold*100),
 			"max_age", priceGuardMaxAge.String(),
 			"update_on_blocked", updateOnBlocked,
@@ -240,7 +239,8 @@ func (c *Client) Start(
 	}
 
 	if autoUnbondingFrequency > 0 {
-		c.logger.Info("Auto unbonding enabled",
+		c.logger.Info(
+			"Auto unbonding enabled",
 			"frequency", autoUnbondingFrequency,
 			"amount", autoUnbondingAmount,
 			"max_stake_percentage", autoUnbondingMaxStakePercentage,
@@ -262,7 +262,8 @@ func (c *Client) Start(
 		if _, _, err := parseAutoBalanceExecutionTime(viper.GetString(daemonflags.FlagAutoBalanceExecutionTime)); err != nil {
 			return err
 		}
-		c.logger.Info("Auto balance-to-keep enabled",
+		c.logger.Info(
+			"Auto balance-to-keep enabled",
 			"balance_to_keep_loya", autoBalanceToKeep,
 			"execution_time", viper.GetString(daemonflags.FlagAutoBalanceExecutionTime),
 			"eth_addr", "0x"+autoBalanceEthAddr,
@@ -280,14 +281,19 @@ func (c *Client) Start(
 	c.cosmosCtx = c.cosmosCtx.WithChainID(chainId)
 	c.cosmosCtx = c.cosmosCtx.WithHomeDir(homeDir)
 	c.cosmosCtx = c.cosmosCtx.WithKeyringDir(homeDir)
-	c.cosmosCtx = c.cosmosCtx.WithGRPCClient(conn)
 	c.cosmosCtx = c.cosmosCtx.WithBroadcastMode(brdcstMode)
 	c.cosmosCtx = c.cosmosCtx.WithAccountRetriever(authtypes.AccountRetriever{})
 
-	rpcClient, err := rpchttp.New(nodeUri, "/websocket")
+	rpcManager, err := newRPCEndpointManager(rpcEndpoints, c.logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize RPC endpoint manager: %w", err)
+	}
+	rpcClient, rpcEndpoint, err := rpcManager.currentClient()
 	if err != nil {
 		return fmt.Errorf("failed to create RPC client: %w", err)
 	}
+	c.logger.Info("CometBFT RPC client established", "endpoint", rpcEndpoint)
+	c.rpcManager = rpcManager
 	c.cosmosCtx = c.cosmosCtx.WithClient(rpcClient)
 
 	encodingConfig := CreateEncodingConfig()
@@ -318,6 +324,200 @@ func (c *Client) Start(
 	)
 
 	return nil
+}
+
+func (c *Client) connectInitialGRPCEndpoint(ctx context.Context) error {
+	c.logger.Info("Establishing gRPC connection", "endpoint", c.grpcManager.currentEndpoint())
+	conn, endpoint, err := c.grpcManager.currentConnection(ctx)
+	if err != nil {
+		c.logger.Warn("Failed to establish gRPC connection, trying fallback endpoint", "endpoint", endpoint, "error", err)
+		for attempt := 0; attempt < c.grpcManager.endpointCount()-1; attempt++ {
+			conn, endpoint, err = c.grpcManager.nextConnection(ctx)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("failed to establish gRPC connection to Cosmos query services: %w", err)
+		}
+	}
+
+	c.setGRPCConnection(conn)
+	c.logger.Info("gRPC connection established successfully", "endpoint", endpoint)
+	return nil
+}
+
+func (c *Client) setGRPCConnection(conn *grpc.ClientConn) {
+	c.grpcConn = conn
+	c.cosmosCtx = c.cosmosCtx.WithGRPCClient(conn)
+
+	// Rebuild all generated clients so subsequent queries use the active connection.
+	c.OracleQueryClient = oracletypes.NewQueryClient(conn)
+	c.BankClient = banktypes.NewQueryClient(conn)
+	c.ReporterClient = reportertypes.NewQueryClient(conn)
+	c.GlobalfeeClient = globalfeetypes.NewQueryClient(conn)
+	c.CmtService = cmtservice.NewServiceClient(conn)
+	c.AuthClient = authtypes.NewQueryClient(conn)
+}
+
+func (c *Client) withGRPCQueryClient(call func() error) error {
+	c.grpcMu.RLock()
+	defer c.grpcMu.RUnlock()
+	return call()
+}
+
+func (c *Client) reconnectGRPCEndpoint(ctx context.Context, operation string, lastErr error) error {
+	c.grpcMu.Lock()
+	defer c.grpcMu.Unlock()
+
+	oldConn := c.grpcConn
+	c.logger.Warn(
+		"Cosmos gRPC operation failed, trying fallback endpoint",
+		"operation", operation,
+		"endpoint", c.grpcManager.currentEndpoint(),
+		"error", lastErr,
+	)
+
+	conn, endpoint, err := c.grpcManager.nextConnection(ctx)
+	if err != nil {
+		return err
+	}
+	c.setGRPCConnection(conn)
+
+	if oldConn != nil && c.grpcClient != nil {
+		if err := c.grpcClient.CloseConnection(oldConn); err != nil {
+			c.logger.Warn("Failed to close previous gRPC connection", "error", err)
+		}
+	}
+	c.logger.Info("Cosmos gRPC connection re-established", "endpoint", endpoint)
+	return nil
+}
+
+func (c *Client) withGRPCFallback(ctx context.Context, operation string, call func() error) error {
+	err := c.withGRPCQueryClient(call)
+	if !shouldFallbackGRPCError(ctx, err) || c.grpcManager == nil {
+		return err
+	}
+
+	lastErr := err
+	for attempt := 0; attempt < c.grpcManager.endpointCount()-1; attempt++ {
+		if err := c.reconnectGRPCEndpoint(ctx, operation, lastErr); err != nil {
+			return fmt.Errorf("%s failed on gRPC endpoints: %w; last error: %w", operation, err, lastErr)
+		}
+
+		err = c.withGRPCQueryClient(call)
+		if err == nil {
+			return nil
+		}
+		if !shouldFallbackGRPCError(ctx, err) {
+			return err
+		}
+		lastErr = err
+	}
+
+	return fmt.Errorf("%s failed on all gRPC endpoints: %w", operation, lastErr)
+}
+
+func (c *Client) RestorePrimaryEndpointsPeriodically(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	ticker := time.NewTicker(primaryEndpointCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.tryRestorePrimaryRPCEndpoint(ctx)
+			c.tryRestorePrimaryGRPCEndpoint(ctx)
+		}
+	}
+}
+
+func (c *Client) tryRestorePrimaryRPCEndpoint(ctx context.Context) {
+	if c.rpcManager == nil || c.rpcManager.usingPrimary() {
+		return
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, primaryEndpointProbeTimeout)
+	defer cancel()
+
+	rpcClient, endpoint, err := c.rpcManager.primaryClient()
+	if err != nil {
+		c.logger.Warn("Primary CometBFT RPC endpoint is not ready", "endpoint", endpoint, "error", err)
+		return
+	}
+	status, err := rpcClient.Status(probeCtx)
+	if err != nil {
+		c.logger.Warn("Primary CometBFT RPC endpoint health check failed", "endpoint", endpoint, "error", err)
+		return
+	}
+	if status.NodeInfo.Network != c.cosmosCtx.ChainID {
+		c.logger.Warn(
+			"Primary CometBFT RPC endpoint returned unexpected chain ID",
+			"endpoint", endpoint,
+			"expected_chain_id", c.cosmosCtx.ChainID,
+			"actual_chain_id", status.NodeInfo.Network,
+		)
+		return
+	}
+
+	c.rpcManager.switchToPrimary()
+}
+
+func (c *Client) tryRestorePrimaryGRPCEndpoint(ctx context.Context) {
+	if c.grpcManager == nil || c.grpcManager.usingPrimary() {
+		return
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, primaryEndpointProbeTimeout)
+	defer cancel()
+
+	conn, endpoint, err := c.grpcManager.primaryConnection(probeCtx)
+	if err != nil {
+		c.logger.Warn("Primary Cosmos gRPC endpoint is not ready", "endpoint", endpoint, "error", err)
+		return
+	}
+
+	resp, err := cmtservice.NewServiceClient(conn).GetNodeInfo(probeCtx, &cmtservice.GetNodeInfoRequest{})
+	if err != nil {
+		c.closeGRPCConnection(conn)
+		c.logger.Warn("Primary Cosmos gRPC endpoint health check failed", "endpoint", endpoint, "error", err)
+		return
+	}
+	if resp.DefaultNodeInfo.Network != c.cosmosCtx.ChainID {
+		c.closeGRPCConnection(conn)
+		c.logger.Warn(
+			"Primary Cosmos gRPC endpoint returned unexpected chain ID",
+			"endpoint", endpoint,
+			"expected_chain_id", c.cosmosCtx.ChainID,
+			"actual_chain_id", resp.DefaultNodeInfo.Network,
+		)
+		return
+	}
+
+	c.grpcMu.Lock()
+	if c.grpcManager.usingPrimary() {
+		c.grpcMu.Unlock()
+		c.closeGRPCConnection(conn)
+		return
+	}
+	oldConn := c.grpcConn
+	c.setGRPCConnection(conn)
+	c.grpcManager.switchToPrimary()
+	c.grpcMu.Unlock()
+
+	c.closeGRPCConnection(oldConn)
+}
+
+func (c *Client) closeGRPCConnection(conn *grpc.ClientConn) {
+	if conn == nil || c.grpcClient == nil {
+		return
+	}
+	if err := c.grpcClient.CloseConnection(conn); err != nil {
+		c.logger.Warn("Failed to close gRPC connection", "error", err)
+	}
 }
 
 func StartReporterDaemonTaskLoop(
@@ -351,6 +551,9 @@ func StartReporterDaemonTaskLoop(
 			client.logger.Warn("Reporter not found, retrying...", "selector_address", client.accAddr.String())
 		}
 	}
+
+	wg.Add(1)
+	go client.RestorePrimaryEndpointsPeriodically(ctx, wg)
 
 	select {
 	case <-ctx.Done():
@@ -427,7 +630,12 @@ func (c *Client) checkReporter(ctx context.Context) bool {
 		}
 
 		// First try to check if the address is a reporter directly
-		reporterResp, err := c.ReporterClient.Reporter(ctx, &reportertypes.QueryReporterRequest{ReporterAddress: c.accAddr.String()})
+		var reporterResp *reportertypes.QueryReporterResponse
+		err := c.withGRPCFallback(ctx, "reporter lookup", func() error {
+			var err error
+			reporterResp, err = c.ReporterClient.Reporter(ctx, &reportertypes.QueryReporterRequest{ReporterAddress: c.accAddr.String()})
+			return err
+		})
 		if err == nil {
 			c.logger.Info("Reporter found (direct)", "address", c.accAddr.String(), "reporter", reporterResp)
 			return true
@@ -441,7 +649,12 @@ func (c *Client) checkReporter(ctx context.Context) bool {
 
 		c.logger.Debug("Direct reporter check failed, trying selector", "error", err, "address", c.accAddr.String())
 		// If not a reporter, check if it's a selector that has selected a reporter
-		selectorResp, err := c.ReporterClient.SelectorReporter(ctx, &reportertypes.QuerySelectorReporterRequest{SelectorAddress: c.accAddr.String()})
+		var selectorResp *reportertypes.QuerySelectorReporterResponse
+		err = c.withGRPCFallback(ctx, "selector reporter lookup", func() error {
+			var err error
+			selectorResp, err = c.ReporterClient.SelectorReporter(ctx, &reportertypes.QuerySelectorReporterRequest{SelectorAddress: c.accAddr.String()})
+			return err
+		})
 		if err == nil {
 			c.logger.Info("Reporter found (via selector)", "address", c.accAddr.String(), "reporter", selectorResp.Reporter)
 			return true
@@ -527,6 +740,8 @@ func (c *Client) Stop() {
 		c.broadcastWg.Wait()
 
 		// Close gRPC connection
+		c.grpcMu.Lock()
+		defer c.grpcMu.Unlock()
 		if c.grpcConn != nil && c.grpcClient != nil {
 			if err := c.grpcClient.CloseConnection(c.grpcConn); err != nil {
 				c.logger.Error("Failed to close gRPC connection", "error", err)

--- a/reporter/client/client.go
+++ b/reporter/client/client.go
@@ -92,6 +92,7 @@ type Client struct {
 	grpcConn    *grpc.ClientConn
 	grpcClient  daemontypes.GrpcClient
 	grpcManager *grpcEndpointManager
+	rpcMu       sync.RWMutex
 	rpcManager  *rpcEndpointManager
 
 	wg          sync.WaitGroup
@@ -294,7 +295,7 @@ func (c *Client) Start(
 	}
 	c.logger.Info("CometBFT RPC client established", "endpoint", rpcEndpoint)
 	c.rpcManager = rpcManager
-	c.cosmosCtx = c.cosmosCtx.WithClient(rpcClient)
+	c.setRPCClient(rpcClient)
 
 	encodingConfig := CreateEncodingConfig()
 	c.cosmosCtx = c.cosmosCtx.WithCodec(encodingConfig.Codec).WithInterfaceRegistry(encodingConfig.InterfaceRegistry).WithTxConfig(encodingConfig.TxConfig)
@@ -463,6 +464,7 @@ func (c *Client) tryRestorePrimaryRPCEndpoint(ctx context.Context) {
 		return
 	}
 
+	c.setRPCClient(rpcClient)
 	c.rpcManager.switchToPrimary()
 }
 
@@ -518,6 +520,18 @@ func (c *Client) closeGRPCConnection(conn *grpc.ClientConn) {
 	if err := c.grpcClient.CloseConnection(conn); err != nil {
 		c.logger.Warn("Failed to close gRPC connection", "error", err)
 	}
+}
+
+func (c *Client) setRPCClient(rpcClient client.CometRPC) {
+	c.rpcMu.Lock()
+	defer c.rpcMu.Unlock()
+	c.cosmosCtx = c.cosmosCtx.WithClient(rpcClient)
+}
+
+func (c *Client) rpcContextWithClient(rpcClient client.CometRPC) client.Context {
+	c.rpcMu.RLock()
+	defer c.rpcMu.RUnlock()
+	return c.cosmosCtx.WithClient(rpcClient)
 }
 
 func StartReporterDaemonTaskLoop(

--- a/reporter/client/current_query.go
+++ b/reporter/client/current_query.go
@@ -9,8 +9,12 @@ import (
 )
 
 func (c *Client) CurrentQuery(ctx context.Context) ([]byte, *oracletypes.QueryMeta, error) {
-	response, err := c.OracleQueryClient.CurrentCyclelistQuery(ctx, &oracletypes.QueryCurrentCyclelistQueryRequest{})
-	if err != nil {
+	var response *oracletypes.QueryCurrentCyclelistQueryResponse
+	if err := c.withGRPCFallback(ctx, "current cyclelist query", func() error {
+		var err error
+		response, err = c.OracleQueryClient.CurrentCyclelistQuery(ctx, &oracletypes.QueryCurrentCyclelistQueryRequest{})
+		return err
+	}); err != nil {
 		return nil, nil, fmt.Errorf("error calling 'CurrentCyclelistQuery': %w", err)
 	}
 	querydata, err := utils.QueryBytesFromString(response.QueryData)

--- a/reporter/client/grpc_endpoint_manager.go
+++ b/reporter/client/grpc_endpoint_manager.go
@@ -1,0 +1,152 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	daemontypes "github.com/tellor-io/layer-daemons/types"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"cosmossdk.io/log"
+)
+
+type grpcConnectionFactory func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
+
+type grpcEndpointManager struct {
+	mu        sync.RWMutex
+	endpoints []string
+	current   int
+	factory   grpcConnectionFactory
+	logger    log.Logger
+}
+
+func newGRPCEndpointManager(endpoints []string, logger log.Logger, grpcClient daemontypes.GrpcClient) (*grpcEndpointManager, error) {
+	if grpcClient == nil {
+		return nil, fmt.Errorf("gRPC client is required")
+	}
+	return newGRPCEndpointManagerWithFactory(endpoints, logger, grpcClient.NewTcpConnection)
+}
+
+func newGRPCEndpointManagerWithFactory(endpoints []string, logger log.Logger, factory grpcConnectionFactory) (*grpcEndpointManager, error) {
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("no gRPC endpoints provided")
+	}
+	if factory == nil {
+		return nil, fmt.Errorf("gRPC connection factory is required")
+	}
+	return &grpcEndpointManager{
+		endpoints: append([]string(nil), endpoints...),
+		factory:   factory,
+		logger:    logger,
+	}, nil
+}
+
+func (m *grpcEndpointManager) currentEndpoint() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.endpoints[m.current]
+}
+
+func (m *grpcEndpointManager) endpointCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.endpoints)
+}
+
+func (m *grpcEndpointManager) usingPrimary() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.current == 0
+}
+
+func (m *grpcEndpointManager) primaryEndpoint() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.endpoints[0]
+}
+
+func (m *grpcEndpointManager) currentConnection(ctx context.Context) (*grpc.ClientConn, string, error) {
+	endpoint := m.currentEndpoint()
+	conn, err := m.factory(ctx, endpoint)
+	if err != nil {
+		return nil, endpoint, err
+	}
+	return conn, endpoint, nil
+}
+
+func (m *grpcEndpointManager) primaryConnection(ctx context.Context) (*grpc.ClientConn, string, error) {
+	endpoint := m.primaryEndpoint()
+	conn, err := m.factory(ctx, endpoint)
+	if err != nil {
+		return nil, endpoint, err
+	}
+	return conn, endpoint, nil
+}
+
+func (m *grpcEndpointManager) switchToPrimary() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.current == 0 {
+		return
+	}
+	m.current = 0
+	m.logger.Info("Switched Cosmos gRPC endpoint back to primary", "endpoint", m.endpoints[0])
+}
+
+func (m *grpcEndpointManager) nextConnection(ctx context.Context) (*grpc.ClientConn, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var errs []string
+	for offset := 1; offset < len(m.endpoints); offset++ {
+		idx := (m.current + offset) % len(m.endpoints)
+		endpoint := m.endpoints[idx]
+		conn, err := m.factory(ctx, endpoint)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", endpoint, err))
+			continue
+		}
+		m.current = idx
+		m.logger.Warn("Switched Cosmos gRPC endpoint", "endpoint", endpoint)
+		return conn, endpoint, nil
+	}
+
+	if len(errs) == 0 {
+		return nil, "", fmt.Errorf("no fallback gRPC endpoints configured")
+	}
+	return nil, "", fmt.Errorf("failed to create fallback gRPC connections: %s", strings.Join(errs, "; "))
+}
+
+func shouldFallbackGRPCError(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	case codes.OK, codes.Canceled, codes.InvalidArgument, codes.NotFound, codes.AlreadyExists,
+		codes.PermissionDenied, codes.Unauthenticated, codes.FailedPrecondition, codes.OutOfRange,
+		codes.Unimplemented:
+		return false
+	}
+
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "connection reset") ||
+		strings.Contains(errStr, "connection closed") ||
+		strings.Contains(errStr, "transport is closing") ||
+		strings.Contains(errStr, "transport: error while dialing") ||
+		strings.Contains(errStr, "timeout") ||
+		strings.Contains(errStr, "deadline exceeded") ||
+		strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "eof") ||
+		strings.Contains(errStr, "bad gateway") ||
+		strings.Contains(errStr, "service unavailable") ||
+		strings.Contains(errStr, "gateway timeout")
+}

--- a/reporter/client/grpc_endpoint_manager_test.go
+++ b/reporter/client/grpc_endpoint_manager_test.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"cosmossdk.io/log"
+)
+
+func TestGRPCEndpointManagerUsesFirstEndpoint(t *testing.T) {
+	manager, err := newGRPCEndpointManagerWithFactory([]string{"grpc1", "grpc2"}, log.NewNopLogger(), func(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	_, endpoint, err := manager.currentConnection(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "grpc1", endpoint)
+}
+
+func TestGRPCEndpointManagerFallbackSkipsFactoryFailures(t *testing.T) {
+	manager, err := newGRPCEndpointManagerWithFactory([]string{"grpc1", "bad-grpc", "grpc3"}, log.NewNopLogger(), func(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+		if endpoint == "bad-grpc" {
+			return nil, fmt.Errorf("bad endpoint")
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	_, endpoint, err := manager.nextConnection(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "grpc3", endpoint)
+	require.Equal(t, "grpc3", manager.currentEndpoint())
+}
+
+func TestGRPCEndpointManagerSwitchesBackToPrimary(t *testing.T) {
+	manager, err := newGRPCEndpointManagerWithFactory([]string{"grpc1", "grpc2"}, log.NewNopLogger(), func(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	_, endpoint, err := manager.nextConnection(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "grpc2", endpoint)
+	require.False(t, manager.usingPrimary())
+
+	manager.switchToPrimary()
+
+	require.True(t, manager.usingPrimary())
+	require.Equal(t, "grpc1", manager.currentEndpoint())
+}
+
+func TestShouldFallbackGRPCError(t *testing.T) {
+	ctx := context.Background()
+
+	require.True(t, shouldFallbackGRPCError(ctx, status.Error(codes.Unavailable, "connection refused")))
+	require.True(t, shouldFallbackGRPCError(ctx, status.Error(codes.DeadlineExceeded, "deadline exceeded")))
+	require.False(t, shouldFallbackGRPCError(ctx, status.Error(codes.NotFound, "query not found")))
+	require.False(t, shouldFallbackGRPCError(ctx, status.Error(codes.InvalidArgument, "bad request")))
+}
+
+func TestShouldFallbackGRPCErrorHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.False(t, shouldFallbackGRPCError(ctx, status.Error(codes.Unavailable, "connection refused")))
+}

--- a/reporter/client/reporter_monitors.go
+++ b/reporter/client/reporter_monitors.go
@@ -147,14 +147,19 @@ func (c *Client) MonitorForTippedQueries(ctx context.Context, wg *sync.WaitGroup
 			return
 		case <-ticker.C:
 			queryCtx, cancel := context.WithTimeout(ctx, defaultQueryTimeout)
-			res, err := c.OracleQueryClient.TippedQueriesForDaemon(queryCtx, &oracletypes.QueryTippedQueriesForDaemonRequest{
-				Pagination: &query.PageRequest{
-					Offset: 0,
-				},
+			var res *oracletypes.QueryTippedQueriesForDaemonResponse
+			err := c.withGRPCFallback(queryCtx, "tipped queries lookup", func() error {
+				var err error
+				res, err = c.OracleQueryClient.TippedQueriesForDaemon(queryCtx, &oracletypes.QueryTippedQueriesForDaemonRequest{
+					Pagination: &query.PageRequest{
+						Offset: 0,
+					},
+				})
+				return err
 			})
 			cancel()
 
-			if err != nil || len(res.Queries) == 0 {
+			if err != nil || res == nil || len(res.Queries) == 0 {
 				if err != nil {
 					// Exponential backoff on error
 					retryDelay *= 2
@@ -172,7 +177,7 @@ func (c *Client) MonitorForTippedQueries(ctx context.Context, wg *sync.WaitGroup
 				ticker.Reset(retryDelay)
 			}
 
-			status, err := c.cosmosCtx.Client.Status(ctx)
+			status, err := c.Status(ctx)
 			if err != nil {
 				continue
 			}
@@ -303,8 +308,13 @@ func (c *Client) AutoUnbondStakePeriodically(ctx context.Context, wg *sync.WaitG
 			return
 		case <-ticker.C:
 			c.logger.Info("Trying to unbond stake")
-			reporterData, err := c.ReporterClient.SelectionsTo(ctx, &reportertypes.QuerySelectionsToRequest{
-				ReporterAddress: c.accAddr.String(),
+			var reporterData *reportertypes.QuerySelectionsToResponse
+			err := c.withGRPCFallback(ctx, "reporter selections lookup", func() error {
+				var err error
+				reporterData, err = c.ReporterClient.SelectionsTo(ctx, &reportertypes.QuerySelectionsToRequest{
+					ReporterAddress: c.accAddr.String(),
+				})
+				return err
 			})
 			if err != nil {
 				c.logger.Error("error getting reporter data", "error", err)
@@ -384,9 +394,14 @@ func (c *Client) AutoBridgeWalletExcessPeriodically(ctx context.Context, wg *syn
 
 		c.logger.Info("Auto balance-to-keep: checking wallet balance")
 
-		balResp, err := c.BankClient.Balance(ctx, &banktypes.QueryBalanceRequest{
-			Address: c.accAddr.String(),
-			Denom:   "loya",
+		var balResp *banktypes.QueryBalanceResponse
+		err = c.withGRPCFallback(ctx, "wallet balance lookup", func() error {
+			var err error
+			balResp, err = c.BankClient.Balance(ctx, &banktypes.QueryBalanceRequest{
+				Address: c.accAddr.String(),
+				Denom:   "loya",
+			})
+			return err
 		})
 		if err != nil {
 			c.logger.Error("auto balance-to-keep: failed to query wallet balance", "error", err)

--- a/reporter/client/rpc_endpoint_manager.go
+++ b/reporter/client/rpc_endpoint_manager.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+
+	"cosmossdk.io/log"
+
+	cosmosclient "github.com/cosmos/cosmos-sdk/client"
+)
+
+type rpcClientFactory func(endpoint string) (cosmosclient.CometRPC, error)
+
+type rpcEndpointManager struct {
+	mu        sync.RWMutex
+	endpoints []string
+	current   int
+	factory   rpcClientFactory
+	logger    log.Logger
+}
+
+func newRPCEndpointManager(endpoints []string, logger log.Logger) (*rpcEndpointManager, error) {
+	return newRPCEndpointManagerWithFactory(endpoints, logger, func(endpoint string) (cosmosclient.CometRPC, error) {
+		return rpchttp.New(endpoint, "/websocket")
+	})
+}
+
+func newRPCEndpointManagerWithFactory(endpoints []string, logger log.Logger, factory rpcClientFactory) (*rpcEndpointManager, error) {
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("no RPC endpoints provided")
+	}
+	if factory == nil {
+		return nil, fmt.Errorf("RPC client factory is required")
+	}
+	return &rpcEndpointManager{
+		endpoints: append([]string(nil), endpoints...),
+		factory:   factory,
+		logger:    logger,
+	}, nil
+}
+
+func (m *rpcEndpointManager) currentEndpoint() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.endpoints[m.current]
+}
+
+func (m *rpcEndpointManager) endpointCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.endpoints)
+}
+
+func (m *rpcEndpointManager) usingPrimary() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.current == 0
+}
+
+func (m *rpcEndpointManager) primaryEndpoint() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.endpoints[0]
+}
+
+func (m *rpcEndpointManager) currentClient() (cosmosclient.CometRPC, string, error) {
+	endpoint := m.currentEndpoint()
+	client, err := m.factory(endpoint)
+	if err != nil {
+		return nil, endpoint, err
+	}
+	return client, endpoint, nil
+}
+
+func (m *rpcEndpointManager) primaryClient() (cosmosclient.CometRPC, string, error) {
+	endpoint := m.primaryEndpoint()
+	client, err := m.factory(endpoint)
+	if err != nil {
+		return nil, endpoint, err
+	}
+	return client, endpoint, nil
+}
+
+func (m *rpcEndpointManager) switchToPrimary() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.current == 0 {
+		return
+	}
+	m.current = 0
+	m.logger.Info("Switched CometBFT RPC endpoint back to primary", "endpoint", m.endpoints[0])
+}
+
+func (m *rpcEndpointManager) nextClient() (cosmosclient.CometRPC, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var errs []string
+	for offset := 1; offset < len(m.endpoints); offset++ {
+		idx := (m.current + offset) % len(m.endpoints)
+		endpoint := m.endpoints[idx]
+		client, err := m.factory(endpoint)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", endpoint, err))
+			continue
+		}
+		m.current = idx
+		m.logger.Warn("Switched CometBFT RPC endpoint", "endpoint", endpoint)
+		return client, endpoint, nil
+	}
+
+	if len(errs) == 0 {
+		return nil, "", fmt.Errorf("no fallback RPC endpoints configured")
+	}
+	return nil, "", fmt.Errorf("failed to create fallback RPC clients: %s", strings.Join(errs, "; "))
+}
+
+func shouldFallbackRPCError(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+
+	errStr := strings.ToLower(err.Error())
+	if strings.Contains(errStr, "not found") ||
+		strings.Contains(errStr, "error code:") ||
+		strings.Contains(errStr, "insufficient funds") ||
+		strings.Contains(errStr, "account sequence mismatch") {
+		return false
+	}
+
+	return strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "connection reset") ||
+		strings.Contains(errStr, "connection closed") ||
+		strings.Contains(errStr, "timeout") ||
+		strings.Contains(errStr, "deadline exceeded") ||
+		strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "eof") ||
+		strings.Contains(errStr, "bad gateway") ||
+		strings.Contains(errStr, "service unavailable") ||
+		strings.Contains(errStr, "gateway timeout")
+}

--- a/reporter/client/rpc_endpoint_manager_test.go
+++ b/reporter/client/rpc_endpoint_manager_test.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log"
+
+	cosmosclient "github.com/cosmos/cosmos-sdk/client"
+)
+
+func TestRPCEndpointManagerUsesFirstEndpoint(t *testing.T) {
+	manager, err := newRPCEndpointManagerWithFactory([]string{"node1", "node2"}, log.NewNopLogger(), func(endpoint string) (cosmosclient.CometRPC, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	_, endpoint, err := manager.currentClient()
+	require.NoError(t, err)
+	require.Equal(t, "node1", endpoint)
+}
+
+func TestRPCEndpointManagerFallbackSkipsFactoryFailures(t *testing.T) {
+	manager, err := newRPCEndpointManagerWithFactory([]string{"node1", "bad-node", "node3"}, log.NewNopLogger(), func(endpoint string) (cosmosclient.CometRPC, error) {
+		if endpoint == "bad-node" {
+			return nil, fmt.Errorf("bad endpoint")
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	_, endpoint, err := manager.nextClient()
+	require.NoError(t, err)
+	require.Equal(t, "node3", endpoint)
+	require.Equal(t, "node3", manager.currentEndpoint())
+}
+
+func TestRPCEndpointManagerSwitchesBackToPrimary(t *testing.T) {
+	manager, err := newRPCEndpointManagerWithFactory([]string{"node1", "node2"}, log.NewNopLogger(), func(endpoint string) (cosmosclient.CometRPC, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	_, endpoint, err := manager.nextClient()
+	require.NoError(t, err)
+	require.Equal(t, "node2", endpoint)
+	require.False(t, manager.usingPrimary())
+
+	manager.switchToPrimary()
+
+	require.True(t, manager.usingPrimary())
+	require.Equal(t, "node1", manager.currentEndpoint())
+}
+
+func TestShouldFallbackRPCError(t *testing.T) {
+	ctx := context.Background()
+
+	require.True(t, shouldFallbackRPCError(ctx, fmt.Errorf("connection refused")))
+	require.True(t, shouldFallbackRPCError(ctx, fmt.Errorf("context deadline exceeded")))
+	require.False(t, shouldFallbackRPCError(ctx, fmt.Errorf("tx not found")))
+	require.False(t, shouldFallbackRPCError(ctx, fmt.Errorf("error code: '11' msg: 'out of gas'")))
+}
+
+func TestShouldFallbackRPCErrorHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.False(t, shouldFallbackRPCError(ctx, fmt.Errorf("connection refused")))
+}

--- a/reporter/client/tx_handler.go
+++ b/reporter/client/tx_handler.go
@@ -174,7 +174,7 @@ func (c *Client) WaitForTx(ctx context.Context, hash string) (*cmttypes.ResultTx
 
 	waitedBlockCount := 0
 	for waiting {
-		resp, err := c.cosmosCtx.Client.Tx(ctx, bz, false)
+		resp, err := c.txByHash(ctx, bz)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				if waitedBlockCount == 2 {
@@ -216,7 +216,23 @@ func (c *Client) LatestBlockHeight(ctx context.Context) (int64, error) {
 }
 
 func (c *Client) Status(ctx context.Context) (*cmttypes.ResultStatus, error) {
-	return c.cosmosCtx.Client.Status(ctx)
+	var resp *cmttypes.ResultStatus
+	err := c.withRPCFallback(ctx, "status", func(rpcClient client.CometRPC) error {
+		var err error
+		resp, err = rpcClient.Status(ctx)
+		return err
+	})
+	return resp, err
+}
+
+func (c *Client) txByHash(ctx context.Context, hash []byte) (*cmttypes.ResultTx, error) {
+	var resp *cmttypes.ResultTx
+	err := c.withRPCFallback(ctx, "tx lookup", func(rpcClient client.CometRPC) error {
+		var err error
+		resp, err = rpcClient.Tx(ctx, hash, false)
+		return err
+	})
+	return resp, err
 }
 
 func (c *Client) WaitForBlockHeight(ctx context.Context, h int64) error {
@@ -322,7 +338,8 @@ func (c *Client) sendTx(ctx context.Context, queryMetaId uint64, isBridge bool, 
 		}
 
 		changed, from, to := c.gasEstimator.escalateGasLevel(bucket)
-		c.logger.Info("Detected out-of-gas tx response",
+		c.logger.Info(
+			"Detected out-of-gas tx response",
 			"code", txnResponse.TxResult.Code,
 			"bucket", bucket,
 			"attempt", attempt,
@@ -337,7 +354,8 @@ func (c *Client) sendTx(ctx context.Context, queryMetaId uint64, isBridge bool, 
 
 	if spotPriceTx {
 		from, to := c.gasEstimator.setBucketToMaxLevel(bucket)
-		c.logger.Info("Skipping third spot price send attempt after two failures",
+		c.logger.Info(
+			"Skipping third spot price send attempt after two failures",
 			"bucket", bucket,
 			"from", from,
 			"to", to,
@@ -354,8 +372,12 @@ func (c *Client) maxAttemptsForTx(msg sdk.Msg) int {
 }
 
 func (c *Client) sendTxOnce(ctx context.Context, bucket string, msg ...sdk.Msg) (*cmttypes.ResultTx, string, error) {
-	block, err := c.CmtService.GetLatestBlock(ctx, &cmtservice.GetLatestBlockRequest{})
-	if err != nil {
+	var block *cmtservice.GetLatestBlockResponse
+	if err := c.withGRPCFallback(ctx, "latest block lookup", func() error {
+		var err error
+		block, err = c.CmtService.GetLatestBlock(ctx, &cmtservice.GetLatestBlockRequest{})
+		return err
+	}); err != nil {
 		return nil, "", fmt.Errorf("error getting block: %w", err)
 	}
 	txf := newFactory(c.cosmosCtx)
@@ -368,6 +390,7 @@ func (c *Client) sendTxOnce(ctx context.Context, bucket string, msg ...sdk.Msg) 
 		WithTimeoutHeight(uint64(block.SdkBlock.Header.Height + 2)).
 		WithUnordered(true).
 		WithTimeoutTimestamp(c.GetUniqueUnorderedTimeout())
+	var err error
 	txf, err = txf.Prepare(c.cosmosCtx)
 	if err != nil {
 		return nil, "", fmt.Errorf("error preparing transaction factory: %w", err)
@@ -388,7 +411,7 @@ func (c *Client) sendTxOnce(ctx context.Context, bucket string, msg ...sdk.Msg) 
 	if err != nil {
 		return nil, "", fmt.Errorf("error encoding transaction: %w", err)
 	}
-	res, err := c.cosmosCtx.BroadcastTx(txBytes)
+	res, err := c.broadcastTxWithFallback(ctx, txBytes)
 	if err := handleBroadcastResult(res, err); err != nil {
 		return nil, "", fmt.Errorf("error broadcasting transaction result: %w", err)
 	}
@@ -407,9 +430,63 @@ func (c *Client) sendTxOnce(ctx context.Context, bucket string, msg ...sdk.Msg) 
 	return txnResponse, res.TxHash, nil
 }
 
-func (c *Client) SetGasPrice(ctx context.Context) error {
-	gfResponse, err := c.GlobalfeeClient.MinimumGasPrices(ctx, &globalfeetypes.QueryMinimumGasPricesRequest{})
+func (c *Client) broadcastTxWithFallback(ctx context.Context, txBytes []byte) (*sdk.TxResponse, error) {
+	var resp *sdk.TxResponse
+	err := c.withRPCFallback(ctx, "broadcast tx", func(rpcClient client.CometRPC) error {
+		clientCtx := c.cosmosCtx.WithClient(rpcClient)
+		var err error
+		resp, err = clientCtx.BroadcastTx(txBytes)
+		return err
+	})
+	return resp, err
+}
+
+func (c *Client) withRPCFallback(ctx context.Context, operation string, call func(client.CometRPC) error) error {
+	if c.rpcManager == nil {
+		return call(c.cosmosCtx.Client)
+	}
+
+	rpcClient, endpoint, err := c.rpcManager.currentClient()
 	if err != nil {
+		c.logger.Warn("Failed to create current CometBFT RPC client, trying fallback endpoint", "operation", operation, "endpoint", endpoint, "error", err)
+		rpcClient, endpoint, err = c.rpcManager.nextClient()
+		if err != nil {
+			return fmt.Errorf("create RPC client: %w", err)
+		}
+	}
+
+	err = call(rpcClient)
+	if !shouldFallbackRPCError(ctx, err) {
+		return err
+	}
+
+	lastErr := err
+	for attempt := 0; attempt < c.rpcManager.endpointCount()-1; attempt++ {
+		c.logger.Warn("CometBFT RPC operation failed, trying fallback endpoint", "operation", operation, "endpoint", endpoint, "error", lastErr)
+		rpcClient, endpoint, err = c.rpcManager.nextClient()
+		if err != nil {
+			return fmt.Errorf("%s failed on RPC endpoints: %w; last error: %w", operation, err, lastErr)
+		}
+
+		err = call(rpcClient)
+		if err == nil {
+			return nil
+		}
+		if !shouldFallbackRPCError(ctx, err) {
+			return err
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("%s failed on all RPC endpoints: %w", operation, lastErr)
+}
+
+func (c *Client) SetGasPrice(ctx context.Context) error {
+	var gfResponse *globalfeetypes.QueryMinimumGasPricesResponse
+	if err := c.withGRPCFallback(ctx, "minimum gas prices lookup", func() error {
+		var err error
+		gfResponse, err = c.GlobalfeeClient.MinimumGasPrices(ctx, &globalfeetypes.QueryMinimumGasPricesRequest{})
+		return err
+	}); err != nil {
 		return fmt.Errorf("getting minimum gas price (globalfee): %w", err)
 	}
 	localPrice, err := sdk.ParseDecCoins(c.minGasFee)

--- a/reporter/client/tx_handler.go
+++ b/reporter/client/tx_handler.go
@@ -433,7 +433,7 @@ func (c *Client) sendTxOnce(ctx context.Context, bucket string, msg ...sdk.Msg) 
 func (c *Client) broadcastTxWithFallback(ctx context.Context, txBytes []byte) (*sdk.TxResponse, error) {
 	var resp *sdk.TxResponse
 	err := c.withRPCFallback(ctx, "broadcast tx", func(rpcClient client.CometRPC) error {
-		clientCtx := c.cosmosCtx.WithClient(rpcClient)
+		clientCtx := c.rpcContextWithClient(rpcClient)
 		var err error
 		resp, err = clientCtx.BroadcastTx(txBytes)
 		return err
@@ -453,6 +453,7 @@ func (c *Client) withRPCFallback(ctx context.Context, operation string, call fun
 		if err != nil {
 			return fmt.Errorf("create RPC client: %w", err)
 		}
+		c.setRPCClient(rpcClient)
 	}
 
 	err = call(rpcClient)
@@ -467,6 +468,7 @@ func (c *Client) withRPCFallback(ctx context.Context, operation string, call fun
 		if err != nil {
 			return fmt.Errorf("%s failed on RPC endpoints: %w; last error: %w", operation, err, lastErr)
 		}
+		c.setRPCClient(rpcClient)
 
 		err = call(rpcClient)
 		if err == nil {


### PR DESCRIPTION
in response to issue #27 and to improve reporter uptime in general.
Running this branch on palmito to verify stability. Here's what changed:

env variables for endpoints now configured like:

```
Environment="RPC_NODES=http://127.0.0.1:26657,http://xx.xx.xx.xx:26657"
Environment="GRPC_NODES=0.0.0.0:9090,52.53.241.143:9090"
```

RPC and gRPC endpoints fall back to flags for backwards compatibility. 

The endpoint in position 0 is the primary. After fallback, the daemon will check the primary every 5 minutes and switch back to it if it starts responding normally again.

Questions and Commends welcome!