### PR TITLE
reporter: optional dispute monitor pause reporting while any dispute is open

### DIFF
--- a/app.go
+++ b/app.go
@@ -16,6 +16,7 @@ import (
 	metricsclient "github.com/tellor-io/layer-daemons/metrics/client"
 	pricefeedclient "github.com/tellor-io/layer-daemons/pricefeed/client"
 	reporterclient "github.com/tellor-io/layer-daemons/reporter/client"
+	"github.com/tellor-io/layer-daemons/reporter/dispute"
 	daemonserver "github.com/tellor-io/layer-daemons/server"
 	daemonservertypes "github.com/tellor-io/layer-daemons/server/types"
 	pricefeedtypes "github.com/tellor-io/layer-daemons/server/types/pricefeed"
@@ -134,6 +135,18 @@ func NewApp(
 
 	exchangeQueryConfig := configs.ReadExchangeQueryConfigFile(homePath)
 	marketParamsConfig := configs.ReadMarketParamsConfigFile(homePath)
+
+	// Dispute failsafe (opt-in via DISPUTE_MONITOR_ENABLED): before starting any other
+	// component, refuse to run while there is an open, non-ignored dispute on the network.
+	// CheckBeforeStart panics if one exists; Run keeps watching via events + the API.
+	disputeMonitor := dispute.New(logger, dispute.LoadConfigFromEnv(rpcEndpoints))
+	disputeMonitor.CheckBeforeStart(ctx)
+	appInstance.wg.Add(1)
+	go func() {
+		defer appInstance.wg.Done()
+		disputeMonitor.Run(ctx)
+	}()
+
 	// Start pricefeed client for sending prices for the pricefeed server to consume. These prices
 	// are retrieved via third-party APIs like Binance and then are encoded in-memory and
 	// periodically sent via gRPC to a shared socket with the server.

--- a/app.go
+++ b/app.go
@@ -138,14 +138,18 @@ func NewApp(
 
 	// Dispute failsafe (opt-in via DISPUTE_MONITOR_ENABLED): before starting any other
 	// component, refuse to run while there is an open, non-ignored dispute on the network.
-	// CheckBeforeStart panics if one exists; Run keeps watching via events + the API.
-	disputeMonitor := dispute.New(logger, dispute.LoadConfigFromEnv(rpcEndpoints))
-	disputeMonitor.CheckBeforeStart(ctx)
-	appInstance.wg.Add(1)
-	go func() {
-		defer appInstance.wg.Done()
-		disputeMonitor.Run(ctx)
-	}()
+	// Only create and run the monitor when it is enabled.
+	if disputeCfg := dispute.LoadConfigFromEnv(rpcEndpoints); disputeCfg.Enabled {
+		disputeMonitor := dispute.New(logger, disputeCfg)
+		disputeMonitor.CheckBeforeStart(ctx) // panics if an open, non-ignored dispute exists
+		appInstance.wg.Add(1)
+		go func() {
+			defer appInstance.wg.Done()
+			disputeMonitor.Run(ctx) // keeps watching via events + the API
+		}()
+	} else {
+		logger.Info("dispute monitor disabled")
+	}
 
 	// Start pricefeed client for sending prices for the pricefeed server to consume. These prices
 	// are retrieved via third-party APIs like Binance and then are encoded in-memory and

--- a/reporter/dispute/config_env.go
+++ b/reporter/dispute/config_env.go
@@ -1,0 +1,54 @@
+package dispute
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// LoadConfigFromEnv builds the dispute monitor config from environment variables:
+//
+//	DISPUTE_MONITOR_ENABLED   - "true"/"1"/"yes"/"on" to enable (default off)
+//	API_URLS                  - comma-separated Layer REST API URLs (open-disputes query)
+//	DISPUTE_IGNORE_IDS        - comma-separated dispute IDs to ignore
+//	DISPUTE_CHECK_INTERVAL    - API poll interval (e.g. 1s; default 1s)
+//
+// rpcEndpoints are the daemon's resolved RPC nodes, used for new_dispute event subscription.
+func LoadConfigFromEnv(rpcEndpoints []string) Config {
+	cfg := Config{CheckInterval: time.Second, RPCEndpoints: rpcEndpoints}
+
+	cfg.Enabled = isTrue(os.Getenv("DISPUTE_MONITOR_ENABLED"))
+
+	if urls := os.Getenv("API_URLS"); urls != "" {
+		for _, url := range strings.Split(urls, ",") {
+			if trimmed := strings.TrimSpace(url); trimmed != "" {
+				cfg.LayerAPIURLs = append(cfg.LayerAPIURLs, trimmed)
+			}
+		}
+	}
+
+	if ignoreIDs := os.Getenv("DISPUTE_IGNORE_IDS"); ignoreIDs != "" {
+		for _, idStr := range strings.Split(ignoreIDs, ",") {
+			if id, err := strconv.ParseUint(strings.TrimSpace(idStr), 10, 64); err == nil {
+				cfg.IgnoreDisputes = append(cfg.IgnoreDisputes, id)
+			}
+		}
+	}
+
+	if interval := os.Getenv("DISPUTE_CHECK_INTERVAL"); interval != "" {
+		if d, err := time.ParseDuration(interval); err == nil && d > 0 {
+			cfg.CheckInterval = d
+		}
+	}
+
+	return cfg
+}
+
+func isTrue(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}

--- a/reporter/dispute/config_env.go
+++ b/reporter/dispute/config_env.go
@@ -16,7 +16,7 @@ import (
 //
 // rpcEndpoints are the daemon's resolved RPC nodes, used for new_dispute event subscription.
 func LoadConfigFromEnv(rpcEndpoints []string) Config {
-	cfg := Config{CheckInterval: time.Second, RPCEndpoints: rpcEndpoints}
+	cfg := Config{CheckInterval: 30 * time.Second, RPCEndpoints: rpcEndpoints}
 
 	cfg.Enabled = isTrue(os.Getenv("DISPUTE_MONITOR_ENABLED"))
 

--- a/reporter/dispute/dispute.go
+++ b/reporter/dispute/dispute.go
@@ -1,0 +1,287 @@
+// Package dispute implements the reporter's dispute failsafe: before the reporter starts
+// (and continuously after), it refuses to report while there is an open, non-ignored
+// dispute on the network. It monitors via both the chain API and new_dispute events, and
+// on any non-ignored open dispute it PANICS to exit the process — a robust failsafe that
+// stops reporting immediately. Opt-in via DISPUTE_MONITOR_ENABLED.
+//
+// Ported from the monitor's dispute package; the only design change is dropping the DB
+// failsafe in favor of new_dispute event subscription alongside the API check.
+package dispute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	"golang.org/x/sync/errgroup"
+
+	"cosmossdk.io/log"
+)
+
+const (
+	Component          = "dispute_monitor"
+	ReasonOpenDisputes = "OPEN DISPUTES DETECTED - not safe to continue reporting. Add dispute IDs to DISPUTE_IGNORE_IDS if safe to ignore"
+	// disputeEventQuery matches any tx emitting a new_dispute event.
+	disputeEventQuery    = "tm.event='Tx' AND new_dispute.dispute_id EXISTS"
+	defaultCheckInterval = time.Second
+)
+
+type Config struct {
+	Enabled        bool          // opt-in (DISPUTE_MONITOR_ENABLED)
+	LayerAPIURLs   []string      // Layer REST API URLs for querying open disputes
+	RPCEndpoints   []string      // CometBFT RPC endpoints for new_dispute event subscription
+	IgnoreDisputes []uint64      // Dispute IDs that are safe to ignore
+	CheckInterval  time.Duration // How often the API poll re-checks (default 1s)
+}
+
+type Monitor struct {
+	cfg        Config
+	logger     log.Logger
+	httpClient *http.Client
+}
+
+func New(logger log.Logger, cfg Config) *Monitor {
+	if cfg.CheckInterval <= 0 {
+		cfg.CheckInterval = defaultCheckInterval
+	}
+	return &Monitor{
+		cfg:        cfg,
+		logger:     logger.With("component", Component),
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// Enabled reports whether the monitor is turned on.
+func (m *Monitor) Enabled() bool { return m.cfg.Enabled }
+
+// CheckBeforeStart runs one synchronous dispute check before the reporter starts any other
+// component. If there is an open, non-ignored dispute it panics — so the reporter never
+// starts reporting while a dispute is open. No-op when disabled.
+func (m *Monitor) CheckBeforeStart(ctx context.Context) {
+	if !m.cfg.Enabled {
+		m.logger.Info("dispute monitor disabled")
+		return
+	}
+	if len(m.cfg.LayerAPIURLs) == 0 {
+		m.logger.Error("dispute monitor enabled but no API_URLS configured - the failsafe cannot query disputes")
+	}
+	m.logger.Info("dispute monitor: checking for open disputes before starting any component",
+		"api_urls", m.cfg.LayerAPIURLs, "ignore_disputes", m.cfg.IgnoreDisputes, "check_interval", m.cfg.CheckInterval)
+	m.checkDisputes(ctx)
+}
+
+// Run continuously monitors for open disputes using both new_dispute events and an API
+// poll, panicking on any non-ignored open dispute. No-op when disabled.
+func (m *Monitor) Run(ctx context.Context) {
+	if !m.cfg.Enabled {
+		return
+	}
+	go m.subscribeEvents(ctx)
+
+	// Immediate check, then poll. (Matches the original monitor's behavior.)
+	m.checkDisputes(ctx)
+
+	ticker := time.NewTicker(m.cfg.CheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			m.logger.Info("dispute monitor stopped")
+			return
+		case <-ticker.C:
+			m.checkDisputes(ctx)
+		}
+	}
+}
+
+// checkDisputes queries all API nodes and panics if any non-ignored dispute is open.
+func (m *Monitor) checkDisputes(ctx context.Context) {
+	for _, disputeID := range m.queryAllAPINodes(ctx, m.cfg.LayerAPIURLs) {
+		if !isIgnored(m.cfg.IgnoreDisputes, disputeID) {
+			m.logger.Error("OPEN DISPUTE DETECTED - PANIC", "dispute_id", disputeID, "ignored_ids", m.cfg.IgnoreDisputes)
+			panic(fmt.Sprintf("%s: dispute_id=%d", ReasonOpenDisputes, disputeID))
+		}
+		m.logger.Warn("open dispute found but ignored", "dispute_id", disputeID)
+	}
+}
+
+// subscribeEvents keeps a best-effort new_dispute subscription; on any event it re-checks
+// (which panics if the dispute is not ignored). Falls back to the API poll if unavailable.
+func (m *Monitor) subscribeEvents(ctx context.Context) {
+	if len(m.cfg.RPCEndpoints) == 0 {
+		return
+	}
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		client, err := rpchttp.New(m.cfg.RPCEndpoints[0], "/websocket")
+		if err == nil && !client.IsRunning() {
+			err = client.Start()
+		}
+		if err != nil {
+			m.logger.Warn("dispute monitor: event subscription unavailable, relying on API poll", "error", err)
+			if !sleepCtx(ctx, m.cfg.CheckInterval) {
+				return
+			}
+			continue
+		}
+		sub := fmt.Sprintf("reporter-dispute-monitor-%d", time.Now().UnixNano())
+		evCh, err := client.Subscribe(ctx, sub, disputeEventQuery)
+		if err != nil {
+			m.logger.Warn("dispute monitor: subscribe failed, relying on API poll", "error", err)
+			_ = client.Stop()
+			if !sleepCtx(ctx, m.cfg.CheckInterval) {
+				return
+			}
+			continue
+		}
+		for open := true; open; {
+			select {
+			case <-ctx.Done():
+				_ = client.Unsubscribe(ctx, sub, disputeEventQuery)
+				_ = client.Stop()
+				return
+			case _, ok := <-evCh:
+				if !ok {
+					open = false // channel closed; re-subscribe
+					break
+				}
+				m.logger.Warn("dispute monitor: new_dispute event received - checking")
+				m.checkDisputes(ctx) // panics if not ignored
+			}
+		}
+		_ = client.Unsubscribe(ctx, sub, disputeEventQuery)
+		_ = client.Stop()
+	}
+}
+
+// queryAllAPINodes queries every API URL in parallel and returns the union of open IDs.
+func (m *Monitor) queryAllAPINodes(ctx context.Context, apiURLs []string) []uint64 {
+	if len(apiURLs) == 0 {
+		return nil
+	}
+	type result struct {
+		ids []uint64
+		err error
+	}
+	resultsCh := make(chan result, len(apiURLs))
+
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, apiURL := range apiURLs {
+		url := apiURL
+		g.Go(func() error {
+			ids, err := m.queryDisputesFromAPI(gCtx, url)
+			select {
+			case resultsCh <- result{ids: ids, err: err}:
+			case <-gCtx.Done():
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+	close(resultsCh)
+
+	allIDs := make(map[uint64]struct{})
+	errorCount := 0
+	for res := range resultsCh {
+		if res.err != nil {
+			m.logger.Debug("dispute API query failed", "error", res.err)
+			errorCount++
+			continue
+		}
+		for _, id := range res.ids {
+			allIDs[id] = struct{}{}
+		}
+	}
+	if errorCount == len(apiURLs) && errorCount > 0 {
+		m.logger.Error("all dispute API nodes failed to respond")
+	}
+
+	ids := make([]uint64, 0, len(allIDs))
+	for id := range allIDs {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (m *Monitor) queryDisputesFromAPI(ctx context.Context, baseURL string) ([]uint64, error) {
+	url := fmt.Sprintf("%s/tellor-io/layer/dispute/open-disputes", strings.TrimRight(baseURL, "/"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var parsed struct {
+		OpenDisputes struct {
+			Ids []flexUint64 `json:"ids"`
+		} `json:"openDisputes"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	ids := make([]uint64, 0, len(parsed.OpenDisputes.Ids))
+	for _, id := range parsed.OpenDisputes.Ids {
+		ids = append(ids, uint64(id))
+	}
+	return ids, nil
+}
+
+func isIgnored(ignoreList []uint64, disputeID uint64) bool {
+	for _, ignoreID := range ignoreList {
+		if ignoreID == disputeID {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseDisputeID converts a decimal string to uint64.
+func ParseDisputeID(val string) (uint64, error) {
+	return strconv.ParseUint(val, 10, 64)
+}
+
+// flexUint64 unmarshals a uint64 from either a JSON string (cosmos proto-JSON) or a number.
+type flexUint64 uint64
+
+func (f *flexUint64) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if s == "" || s == "null" {
+		return nil
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*f = flexUint64(v)
+	return nil
+}
+
+// sleepCtx sleeps for d or until ctx is done; returns false if ctx was canceled.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/reporter/dispute/dispute.go
+++ b/reporter/dispute/dispute.go
@@ -10,7 +10,6 @@ package dispute
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,9 +18,13 @@ import (
 	"time"
 
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	disputetypes "github.com/tellor-io/layer/x/dispute/types"
 	"golang.org/x/sync/errgroup"
 
 	"cosmossdk.io/log"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
 
 const (
@@ -44,6 +47,7 @@ type Monitor struct {
 	cfg        Config
 	logger     log.Logger
 	httpClient *http.Client
+	cdc        codec.JSONCodec
 }
 
 func New(logger log.Logger, cfg Config) *Monitor {
@@ -54,20 +58,15 @@ func New(logger log.Logger, cfg Config) *Monitor {
 		cfg:        cfg,
 		logger:     logger.With("component", Component),
 		httpClient: &http.Client{Timeout: 10 * time.Second},
+		cdc:        codec.NewProtoCodec(codectypes.NewInterfaceRegistry()),
 	}
 }
 
-// Enabled reports whether the monitor is turned on.
-func (m *Monitor) Enabled() bool { return m.cfg.Enabled }
-
 // CheckBeforeStart runs one synchronous dispute check before the reporter starts any other
 // component. If there is an open, non-ignored dispute it panics — so the reporter never
-// starts reporting while a dispute is open. No-op when disabled.
+// starts reporting while a dispute is open. The caller only constructs the monitor when it
+// is enabled.
 func (m *Monitor) CheckBeforeStart(ctx context.Context) {
-	if !m.cfg.Enabled {
-		m.logger.Info("dispute monitor disabled")
-		return
-	}
 	if len(m.cfg.LayerAPIURLs) == 0 {
 		m.logger.Error("dispute monitor enabled but no API_URLS configured - the failsafe cannot query disputes")
 	}
@@ -79,9 +78,6 @@ func (m *Monitor) CheckBeforeStart(ctx context.Context) {
 // Run continuously monitors for open disputes using both new_dispute events and an API
 // poll, panicking on any non-ignored open dispute. No-op when disabled.
 func (m *Monitor) Run(ctx context.Context) {
-	if !m.cfg.Enabled {
-		return
-	}
 	go m.subscribeEvents(ctx)
 
 	// Immediate check, then poll. (Matches the original monitor's behavior.)
@@ -229,19 +225,18 @@ func (m *Monitor) queryDisputesFromAPI(ctx context.Context, baseURL string) ([]u
 	if err != nil {
 		return nil, err
 	}
-	var parsed struct {
-		OpenDisputes struct {
-			Ids []flexUint64 `json:"ids"`
-		} `json:"openDisputes"`
+
+	// Decode into the actual layer struct via the proto-JSON codec. This is strict
+	// (gogoproto jsonpb rejects unknown fields), so any change to the chain's response
+	// shape surfaces as an error here instead of being silently dropped.
+	var parsed disputetypes.QueryOpenDisputesResponse
+	if err := m.cdc.UnmarshalJSON(body, &parsed); err != nil {
+		return nil, fmt.Errorf("decode open-disputes response: %w", err)
 	}
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return nil, fmt.Errorf("unmarshal: %w", err)
+	if parsed.OpenDisputes == nil {
+		return nil, fmt.Errorf("unexpected open-disputes response: missing openDisputes field")
 	}
-	ids := make([]uint64, 0, len(parsed.OpenDisputes.Ids))
-	for _, id := range parsed.OpenDisputes.Ids {
-		ids = append(ids, uint64(id))
-	}
-	return ids, nil
+	return parsed.OpenDisputes.Ids, nil
 }
 
 func isIgnored(ignoreList []uint64, disputeID uint64) bool {
@@ -256,22 +251,6 @@ func isIgnored(ignoreList []uint64, disputeID uint64) bool {
 // ParseDisputeID converts a decimal string to uint64.
 func ParseDisputeID(val string) (uint64, error) {
 	return strconv.ParseUint(val, 10, 64)
-}
-
-// flexUint64 unmarshals a uint64 from either a JSON string (cosmos proto-JSON) or a number.
-type flexUint64 uint64
-
-func (f *flexUint64) UnmarshalJSON(b []byte) error {
-	s := strings.Trim(string(b), `"`)
-	if s == "" || s == "null" {
-		return nil
-	}
-	v, err := strconv.ParseUint(s, 10, 64)
-	if err != nil {
-		return err
-	}
-	*f = flexUint64(v)
-	return nil
 }
 
 // sleepCtx sleeps for d or until ctx is done; returns false if ctx was canceled.

--- a/reporter/dispute/dispute.go
+++ b/reporter/dispute/dispute.go
@@ -32,7 +32,7 @@ const (
 	ReasonOpenDisputes = "OPEN DISPUTES DETECTED - not safe to continue reporting. Add dispute IDs to DISPUTE_IGNORE_IDS if safe to ignore"
 	// disputeEventQuery matches any tx emitting a new_dispute event.
 	disputeEventQuery    = "tm.event='Tx' AND new_dispute.dispute_id EXISTS"
-	defaultCheckInterval = time.Second
+	defaultCheckInterval = 30 * time.Second
 )
 
 type Config struct {

--- a/reporter/dispute/dispute_test.go
+++ b/reporter/dispute/dispute_test.go
@@ -2,35 +2,41 @@ package dispute
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	disputetypes "github.com/tellor-io/layer/x/dispute/types"
 
 	"cosmossdk.io/log"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
 
-var queryInterval = 50 * time.Millisecond
+var (
+	queryInterval = 50 * time.Millisecond
+	testCodec     = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+)
 
 func testLogger() log.Logger {
 	return log.NewLogger(os.Stderr, log.LevelOption(zerolog.DebugLevel), log.ColorOption(false))
 }
 
-// mockOpenDisputesResponse returns the open-disputes JSON. IDs are encoded as strings to
-// match cosmos proto-JSON for uint64.
+// mockOpenDisputesResponse marshals the actual layer response struct so the test exercises
+// the real proto-JSON shape (and breaks if the upstream struct changes).
 func mockOpenDisputesResponse(ids []uint64) []byte {
-	strs := make([]string, len(ids))
-	for i, id := range ids {
-		strs[i] = strconv.FormatUint(id, 10)
+	resp := &disputetypes.QueryOpenDisputesResponse{
+		OpenDisputes: &disputetypes.OpenDisputes{Ids: ids},
 	}
-	resp := map[string]any{"openDisputes": map[string]any{"ids": strs}}
-	b, _ := json.Marshal(resp)
+	b, err := testCodec.MarshalJSON(resp)
+	if err != nil {
+		panic(err)
+	}
 	return b
 }
 
@@ -124,12 +130,15 @@ func TestDoesNotPanicWhenDisputeIsIgnored(t *testing.T) {
 	}
 }
 
-func TestDisabledMonitorDoesNothing(t *testing.T) {
-	srv := serveDisputes([]uint64{7})
+func TestErrorsOnMalformedResponse(t *testing.T) {
+	// A response missing the openDisputes structure must be treated as an error (no panic).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
 	defer srv.Close()
-	m := New(testLogger(), Config{Enabled: false, LayerAPIURLs: []string{srv.URL}, CheckInterval: queryInterval})
-	// CheckBeforeStart and Run must be no-ops when disabled (no panic).
-	m.CheckBeforeStart(context.Background())
+	if panicked, msg := runExpectPanic(t, Config{LayerAPIURLs: []string{srv.URL}, CheckInterval: queryInterval}); panicked {
+		t.Fatalf("monitor panicked on a malformed response (should treat as error): %q", msg)
+	}
 }
 
 func TestIsIgnored(t *testing.T) {

--- a/reporter/dispute/dispute_test.go
+++ b/reporter/dispute/dispute_test.go
@@ -1,0 +1,175 @@
+package dispute
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"cosmossdk.io/log"
+)
+
+var queryInterval = 50 * time.Millisecond
+
+func testLogger() log.Logger {
+	return log.NewLogger(os.Stderr, log.LevelOption(zerolog.DebugLevel), log.ColorOption(false))
+}
+
+// mockOpenDisputesResponse returns the open-disputes JSON. IDs are encoded as strings to
+// match cosmos proto-JSON for uint64.
+func mockOpenDisputesResponse(ids []uint64) []byte {
+	strs := make([]string, len(ids))
+	for i, id := range ids {
+		strs[i] = strconv.FormatUint(id, 10)
+	}
+	resp := map[string]any{"openDisputes": map[string]any{"ids": strs}}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func serveDisputes(ids []uint64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(mockOpenDisputesResponse(ids))
+	}))
+}
+
+// runExpectPanic runs the monitor and returns the recovered panic value (or nil).
+func runExpectPanic(t *testing.T, cfg Config) (panicked bool, msg string) {
+	t.Helper()
+	cfg.Enabled = true
+	m := New(testLogger(), cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	panicCh := make(chan any, 1)
+	doneCh := make(chan struct{})
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- r
+			}
+			close(doneCh)
+		}()
+		m.Run(ctx)
+	}()
+
+	select {
+	case p := <-panicCh:
+		s, _ := p.(string)
+		return true, s
+	case <-doneCh:
+		return false, ""
+	case <-time.After(10 * queryInterval):
+		return false, "timeout"
+	}
+}
+
+func TestPanicsOnOpenDisputes_MultiServer(t *testing.T) {
+	open := serveDisputes([]uint64{1, 2, 3})
+	defer open.Close()
+	none := serveDisputes([]uint64{})
+	defer none.Close()
+
+	// One server open, one none → must panic.
+	panicked, msg := runExpectPanic(t, Config{LayerAPIURLs: []string{open.URL, none.URL}, CheckInterval: queryInterval})
+	if !panicked || !strings.Contains(msg, ReasonOpenDisputes) {
+		t.Fatalf("expected panic with %q, got panicked=%v msg=%q", ReasonOpenDisputes, panicked, msg)
+	}
+
+	// Both servers open → must panic.
+	open2 := serveDisputes([]uint64{4, 5})
+	defer open2.Close()
+	panicked, msg = runExpectPanic(t, Config{LayerAPIURLs: []string{open.URL, open2.URL}, CheckInterval: queryInterval})
+	if !panicked || !strings.Contains(msg, "OPEN DISPUTES DETECTED") {
+		t.Fatalf("expected panic (both open), got panicked=%v msg=%q", panicked, msg)
+	}
+}
+
+func TestDoesNotPanicOnErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if panicked, msg := runExpectPanic(t, Config{LayerAPIURLs: []string{srv.URL}, CheckInterval: queryInterval}); panicked {
+		t.Fatalf("monitor panicked on API errors (should not): %q", msg)
+	}
+}
+
+func TestDoesNotPanicWhenNoOpenDisputes(t *testing.T) {
+	srv := serveDisputes([]uint64{})
+	defer srv.Close()
+	if panicked, msg := runExpectPanic(t, Config{LayerAPIURLs: []string{srv.URL}, CheckInterval: queryInterval}); panicked {
+		t.Fatalf("monitor panicked with no open disputes (should not): %q", msg)
+	}
+}
+
+func TestDoesNotPanicWhenDisputeIsIgnored(t *testing.T) {
+	srv := serveDisputes([]uint64{42})
+	defer srv.Close()
+	if panicked, msg := runExpectPanic(t, Config{
+		LayerAPIURLs:   []string{srv.URL},
+		IgnoreDisputes: []uint64{42},
+		CheckInterval:  queryInterval,
+	}); panicked {
+		t.Fatalf("monitor panicked on an ignored dispute (should not): %q", msg)
+	}
+}
+
+func TestDisabledMonitorDoesNothing(t *testing.T) {
+	srv := serveDisputes([]uint64{7})
+	defer srv.Close()
+	m := New(testLogger(), Config{Enabled: false, LayerAPIURLs: []string{srv.URL}, CheckInterval: queryInterval})
+	// CheckBeforeStart and Run must be no-ops when disabled (no panic).
+	m.CheckBeforeStart(context.Background())
+}
+
+func TestIsIgnored(t *testing.T) {
+	if !isIgnored([]uint64{1, 2, 3}, 2) {
+		t.Fatal("2 should be ignored")
+	}
+	if isIgnored([]uint64{1, 2, 3}, 9) {
+		t.Fatal("9 should not be ignored")
+	}
+}
+
+func TestParseDisputeID(t *testing.T) {
+	id, err := ParseDisputeID("123")
+	if err != nil || id != 123 {
+		t.Fatalf("ParseDisputeID(123) = %d, %v", id, err)
+	}
+	if _, err := ParseDisputeID("nope"); err == nil {
+		t.Fatal("expected error for non-numeric id")
+	}
+}
+
+func TestLoadConfigFromEnv(t *testing.T) {
+	t.Setenv("DISPUTE_MONITOR_ENABLED", "true")
+	t.Setenv("API_URLS", "http://a:1317, http://b:1317")
+	t.Setenv("DISPUTE_IGNORE_IDS", "5, 9")
+	t.Setenv("DISPUTE_CHECK_INTERVAL", "3s")
+	cfg := LoadConfigFromEnv([]string{"tcp://rpc:26657"})
+	if !cfg.Enabled {
+		t.Fatal("expected enabled")
+	}
+	if len(cfg.LayerAPIURLs) != 2 || cfg.LayerAPIURLs[1] != "http://b:1317" {
+		t.Fatalf("api urls: %v", cfg.LayerAPIURLs)
+	}
+	if len(cfg.IgnoreDisputes) != 2 || cfg.IgnoreDisputes[0] != 5 {
+		t.Fatalf("ignore: %v", cfg.IgnoreDisputes)
+	}
+	if cfg.CheckInterval != 3*time.Second {
+		t.Fatalf("interval: %v", cfg.CheckInterval)
+	}
+	if len(cfg.RPCEndpoints) != 1 {
+		t.Fatalf("rpc: %v", cfg.RPCEndpoints)
+	}
+}


### PR DESCRIPTION
## What
Opt-in dispute monitor for the reporter. When enabled, the reporter stops reporting while **any dispute is open on the network**, and resumes once they're resolved. Off by default, no change unless enabled.

## Why
It's unsafe to keep reporting during an open dispute; new reports can be pulled into the dispute window.

## How
- **Poll (every 30s):** `OpenDisputes` query → pause if the list is non-empty.
- **Event:** subscribes to `new_dispute` to pause instantly between polls.
- Gates both report paths (spot/tipped/custom + bridge deposits) via an atomic flag.
- Fail-safe: on query error, keeps the previous state. Network-wide check.

## Config
| Flag | Default | |
|---|---|---|
| `--dispute-monitor-enabled` | `false` | pause while any dispute is open |
| `--dispute-monitor-poll-interval` | `30s` | re-check interval |

## Changes
- `reporter/client/dispute_monitor.go`  monitor, poll loop, subscription
- `client.go` query client + wiring, start when enabled
- `broadcast_message.go` gate both report paths
- `cmd/main.go flags