### PR TITLE
Dispute guard: stake filter, multi-dispute threshold, grace-period auto-resume

### DIFF
--- a/reporter/dispute/config_env.go
+++ b/reporter/dispute/config_env.go
@@ -9,10 +9,13 @@ import (
 
 // LoadConfigFromEnv builds the dispute monitor config from environment variables:
 //
-//	DISPUTE_MONITOR_ENABLED   - "true"/"1"/"yes"/"on" to enable (default off)
-//	API_URLS                  - comma-separated Layer REST API URLs (open-disputes query)
-//	DISPUTE_IGNORE_IDS        - comma-separated dispute IDs to ignore
-//	DISPUTE_CHECK_INTERVAL    - API poll interval (e.g. 1s; default 1s)
+//	DISPUTE_MONITOR_ENABLED    - "true"/"1"/"yes"/"on" to enable (default off)
+//	API_URLS                   - comma-separated Layer REST API URLs (open-disputes query)
+//	DISPUTE_IGNORE_IDS         - comma-separated dispute IDs to ignore
+//	DISPUTE_CHECK_INTERVAL     - API poll interval (e.g. 1s; default 30s)
+//	DISPUTE_MIN_REPORTER_POWER - auto-ignore disputes against reports below this power (0=off)
+//	DISPUTE_TRIGGER_THRESHOLD  - qualifying open disputes needed to pause (default 1)
+//	DISPUTE_GRACE_PERIOD       - wait+re-evaluate before halting, e.g. 10m (0=pause now)
 //
 // rpcEndpoints are the daemon's resolved RPC nodes, used for new_dispute event subscription.
 func LoadConfigFromEnv(rpcEndpoints []string) Config {
@@ -39,6 +42,24 @@ func LoadConfigFromEnv(rpcEndpoints []string) Config {
 	if interval := os.Getenv("DISPUTE_CHECK_INTERVAL"); interval != "" {
 		if d, err := time.ParseDuration(interval); err == nil && d > 0 {
 			cfg.CheckInterval = d
+		}
+	}
+
+	if v := os.Getenv("DISPUTE_MIN_REPORTER_POWER"); v != "" {
+		if p, err := strconv.ParseUint(strings.TrimSpace(v), 10, 64); err == nil {
+			cfg.MinReporterPower = p
+		}
+	}
+
+	if v := os.Getenv("DISPUTE_TRIGGER_THRESHOLD"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+			cfg.TriggerThreshold = n
+		}
+	}
+
+	if v := os.Getenv("DISPUTE_GRACE_PERIOD"); v != "" {
+		if d, err := time.ParseDuration(strings.TrimSpace(v)); err == nil && d > 0 {
+			cfg.GracePeriod = d
 		}
 	}
 

--- a/reporter/dispute/dispute.go
+++ b/reporter/dispute/dispute.go
@@ -1,8 +1,16 @@
 // Package dispute implements the reporter's dispute failsafe: before the reporter starts
-// (and continuously after), it refuses to report while there is an open, non-ignored
-// dispute on the network. It monitors via both the chain API and new_dispute events, and
-// on any non-ignored open dispute it PANICS to exit the process — a robust failsafe that
-// stops reporting immediately. Opt-in via DISPUTE_MONITOR_ENABLED.
+// (and continuously after), it refuses to report while there are open, non-ignored disputes
+// on the network. It monitors via both the chain API and new_dispute events, and PANICS to
+// exit the process once the failsafe fires — a robust way to stop reporting immediately.
+// Opt-in via DISPUTE_MONITOR_ENABLED.
+//
+// To resist a low-cost griefing attack (stake 1 TRB, self-dispute, halt the whole reporter
+// network), the trigger is tunable (issue #47), all defaults preserving the original strict
+// behavior:
+//   - DISPUTE_MIN_REPORTER_POWER auto-ignores disputes against tiny-stake reports.
+//   - DISPUTE_TRIGGER_THRESHOLD requires N concurrent qualifying disputes before pausing.
+//   - DISPUTE_GRACE_PERIOD waits and re-evaluates before halting, resuming automatically if
+//     the disputes clear — so a transient or self-resolving dispute needs no operator action.
 //
 // Ported from the monitor's dispute package; the only design change is dropping the DB
 // failsafe in favor of new_dispute event subscription alongside the API check.
@@ -41,6 +49,20 @@ type Config struct {
 	RPCEndpoints   []string      // CometBFT RPC endpoints for new_dispute event subscription
 	IgnoreDisputes []uint64      // Dispute IDs that are safe to ignore
 	CheckInterval  time.Duration // How often the API poll re-checks (default 1s)
+
+	// Grief-prevention knobs (issue #47). Defaults preserve the original strict behavior:
+	// pause on the first open, non-ignored dispute, immediately.
+	//
+	//   - MinReporterPower: when > 0, disputes against a report whose power is below this are
+	//     auto-ignored, so a cheap self-dispute from a tiny stake can't halt the network.
+	//   - TriggerThreshold: number of qualifying open disputes required before pausing
+	//     (default 1). Set to 2+ so a single adversary's self-dispute does not halt reporting.
+	//   - GracePeriod: when > 0, on reaching the threshold the monitor waits this long and
+	//     re-evaluates; if the disputes clear (resolved or now ignorable) it resumes reporting
+	//     without operator intervention instead of halting.
+	MinReporterPower uint64        // DISPUTE_MIN_REPORTER_POWER (0 = disabled)
+	TriggerThreshold int           // DISPUTE_TRIGGER_THRESHOLD (default 1)
+	GracePeriod      time.Duration // DISPUTE_GRACE_PERIOD (0 = pause immediately)
 }
 
 type Monitor struct {
@@ -53,6 +75,9 @@ type Monitor struct {
 func New(logger log.Logger, cfg Config) *Monitor {
 	if cfg.CheckInterval <= 0 {
 		cfg.CheckInterval = defaultCheckInterval
+	}
+	if cfg.TriggerThreshold <= 0 {
+		cfg.TriggerThreshold = 1
 	}
 	return &Monitor{
 		cfg:        cfg,
@@ -96,15 +121,66 @@ func (m *Monitor) Run(ctx context.Context) {
 	}
 }
 
-// checkDisputes queries all API nodes and panics if any non-ignored dispute is open.
+// checkDisputes evaluates the open disputes and triggers the failsafe once the number of
+// qualifying disputes reaches TriggerThreshold. A qualifying dispute is open, not in the
+// ignore list, and — when MinReporterPower is set — against a report whose power is at or
+// above the threshold. Below-threshold counts keep reporting.
 func (m *Monitor) checkDisputes(ctx context.Context) {
-	for _, disputeID := range m.queryAllAPINodes(ctx, m.cfg.LayerAPIURLs) {
-		if !isIgnored(m.cfg.IgnoreDisputes, disputeID) {
-			m.logger.Error("OPEN DISPUTE DETECTED - PANIC", "dispute_id", disputeID, "ignored_ids", m.cfg.IgnoreDisputes)
-			panic(fmt.Sprintf("%s: dispute_id=%d", ReasonOpenDisputes, disputeID))
+	qualifying := m.qualifyingDisputes(ctx)
+	if len(qualifying) < m.cfg.TriggerThreshold {
+		if len(qualifying) > 0 {
+			m.logger.Warn("open disputes below trigger threshold - still reporting",
+				"qualifying", qualifying, "threshold", m.cfg.TriggerThreshold)
 		}
-		m.logger.Warn("open dispute found but ignored", "dispute_id", disputeID)
+		return
 	}
+	m.trigger(ctx, qualifying)
+}
+
+// qualifyingDisputes returns the open dispute IDs that count toward the failsafe: not
+// ignored, and — when MinReporterPower > 0 — disputing a report whose power is at or above
+// the threshold (grief protection: cheap disputes from tiny stakes are auto-ignored). If a
+// dispute's power cannot be read, it is counted, so an API hiccup fails safe toward pausing.
+func (m *Monitor) qualifyingDisputes(ctx context.Context) []uint64 {
+	var qualifying []uint64
+	for _, id := range m.queryAllAPINodes(ctx, m.cfg.LayerAPIURLs) {
+		if isIgnored(m.cfg.IgnoreDisputes, id) {
+			m.logger.Warn("open dispute found but ignored", "dispute_id", id)
+			continue
+		}
+		if m.cfg.MinReporterPower > 0 {
+			power, err := m.queryDisputePower(ctx, id)
+			switch {
+			case err != nil:
+				m.logger.Error("could not read disputed report power - counting dispute (fail safe)", "dispute_id", id, "error", err)
+			case power < m.cfg.MinReporterPower:
+				m.logger.Warn("dispute against low-power reporter auto-ignored", "dispute_id", id, "power", power, "min_power", m.cfg.MinReporterPower)
+				continue
+			}
+		}
+		qualifying = append(qualifying, id)
+	}
+	return qualifying
+}
+
+// trigger halts reporting when the failsafe fires. With a grace period it first waits and
+// re-evaluates: if the disputes clear (resolved, or now below threshold) it resumes reporting
+// without operator intervention; otherwise it panics to stop the reporter immediately.
+func (m *Monitor) trigger(ctx context.Context, qualifying []uint64) {
+	if m.cfg.GracePeriod > 0 {
+		m.logger.Warn("qualifying disputes reached trigger threshold - waiting grace period before halting",
+			"qualifying", qualifying, "threshold", m.cfg.TriggerThreshold, "grace_period", m.cfg.GracePeriod)
+		if !sleepCtx(ctx, m.cfg.GracePeriod) {
+			return
+		}
+		qualifying = m.qualifyingDisputes(ctx)
+		if len(qualifying) < m.cfg.TriggerThreshold {
+			m.logger.Info("disputes cleared during grace period - resuming reporting", "remaining", qualifying)
+			return
+		}
+	}
+	m.logger.Error("OPEN DISPUTES DETECTED - PANIC", "dispute_ids", qualifying, "threshold", m.cfg.TriggerThreshold, "ignored_ids", m.cfg.IgnoreDisputes)
+	panic(fmt.Sprintf("%s: dispute_ids=%v", ReasonOpenDisputes, qualifying))
 }
 
 // subscribeEvents keeps a best-effort new_dispute subscription; on any event it re-checks
@@ -237,6 +313,48 @@ func (m *Monitor) queryDisputesFromAPI(ctx context.Context, baseURL string) ([]u
 		return nil, fmt.Errorf("unexpected open-disputes response: missing openDisputes field")
 	}
 	return parsed.OpenDisputes.Ids, nil
+}
+
+// queryDisputePower returns the power of the report a dispute is challenging, from the first
+// API node that answers. Used for stake-weighted grief filtering.
+func (m *Monitor) queryDisputePower(ctx context.Context, id uint64) (uint64, error) {
+	lastErr := fmt.Errorf("no API URLs configured")
+	for _, baseURL := range m.cfg.LayerAPIURLs {
+		power, err := m.queryDisputePowerFromAPI(ctx, baseURL, id)
+		if err == nil {
+			return power, nil
+		}
+		lastErr = err
+	}
+	return 0, lastErr
+}
+
+func (m *Monitor) queryDisputePowerFromAPI(ctx context.Context, baseURL string, id uint64) (uint64, error) {
+	url := fmt.Sprintf("%s/tellor-io/layer/dispute/dispute/%d", strings.TrimRight(baseURL, "/"), id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+	var parsed disputetypes.QueryDisputeResponse
+	if err := m.cdc.UnmarshalJSON(body, &parsed); err != nil {
+		return 0, fmt.Errorf("decode dispute response: %w", err)
+	}
+	if parsed.Dispute == nil || parsed.Dispute.Metadata == nil {
+		return 0, fmt.Errorf("unexpected dispute response: missing dispute/metadata")
+	}
+	return parsed.Dispute.Metadata.InitialEvidence.Power, nil
 }
 
 func isIgnored(ignoreList []uint64, disputeID uint64) bool {

--- a/reporter/dispute/dispute_test.go
+++ b/reporter/dispute/dispute_test.go
@@ -2,10 +2,13 @@ package dispute
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -141,6 +144,87 @@ func TestErrorsOnMalformedResponse(t *testing.T) {
 	}
 }
 
+// serveDisputesWithPower routes /open-disputes to the ID list and /dispute/dispute/{id} to a
+// minimal per-dispute response carrying the given report power (for stake-filter tests).
+func serveDisputesWithPower(ids []uint64, powers map[uint64]uint64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/open-disputes"):
+			_, _ = w.Write(mockOpenDisputesResponse(ids))
+		case strings.Contains(r.URL.Path, "/dispute/dispute/"):
+			parts := strings.Split(r.URL.Path, "/")
+			id, _ := strconv.ParseUint(parts[len(parts)-1], 10, 64)
+			_, _ = w.Write([]byte(fmt.Sprintf(
+				`{"dispute":{"disputeId":"%d","metadata":{"open":true,"initialEvidence":{"power":"%d"}}}}`, id, powers[id])))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestTriggerThreshold: a single open dispute must not halt reporting when the threshold is 2,
+// but two concurrent disputes must. This defeats a single adversary's self-dispute (issue #47).
+func TestTriggerThreshold(t *testing.T) {
+	one := serveDisputes([]uint64{1})
+	defer one.Close()
+	if panicked, msg := runExpectPanic(t, Config{LayerAPIURLs: []string{one.URL}, TriggerThreshold: 2, CheckInterval: queryInterval}); panicked {
+		t.Fatalf("panicked with 1 dispute under threshold 2: %q", msg)
+	}
+	two := serveDisputes([]uint64{1, 2})
+	defer two.Close()
+	if panicked, _ := runExpectPanic(t, Config{LayerAPIURLs: []string{two.URL}, TriggerThreshold: 2, CheckInterval: queryInterval}); !panicked {
+		t.Fatal("expected panic with 2 disputes at threshold 2")
+	}
+}
+
+// TestStakeWeightedFiltering: a dispute against a below-threshold (griefing) report is
+// auto-ignored, while one against a high-power report still halts reporting (issue #47).
+func TestStakeWeightedFiltering(t *testing.T) {
+	low := serveDisputesWithPower([]uint64{1}, map[uint64]uint64{1: 50})
+	defer low.Close()
+	if panicked, msg := runExpectPanic(t, Config{LayerAPIURLs: []string{low.URL}, MinReporterPower: 100, CheckInterval: queryInterval}); panicked {
+		t.Fatalf("panicked on a low-power (griefing) dispute: %q", msg)
+	}
+	high := serveDisputesWithPower([]uint64{1}, map[uint64]uint64{1: 500})
+	defer high.Close()
+	if panicked, _ := runExpectPanic(t, Config{LayerAPIURLs: []string{high.URL}, MinReporterPower: 100, CheckInterval: queryInterval}); !panicked {
+		t.Fatal("expected panic on a high-power dispute")
+	}
+}
+
+// TestGracePeriodHaltsIfPersists: when the dispute is still open after the grace period, the
+// failsafe still halts.
+func TestGracePeriodHaltsIfPersists(t *testing.T) {
+	srv := serveDisputes([]uint64{7})
+	defer srv.Close()
+	if panicked, _ := runExpectPanic(t, Config{LayerAPIURLs: []string{srv.URL}, GracePeriod: 80 * time.Millisecond, CheckInterval: queryInterval}); !panicked {
+		t.Fatal("expected panic after grace period when the dispute persists")
+	}
+}
+
+// TestGracePeriodResumes: a dispute that clears during the grace period lets reporting resume
+// automatically, with no panic and no operator intervention (issue #47).
+func TestGracePeriodResumes(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !strings.HasSuffix(r.URL.Path, "/open-disputes") {
+			http.NotFound(w, r)
+			return
+		}
+		if calls.Add(1) == 1 { // open on the first poll, cleared thereafter
+			_, _ = w.Write(mockOpenDisputesResponse([]uint64{7}))
+			return
+		}
+		_, _ = w.Write(mockOpenDisputesResponse(nil))
+	}))
+	defer srv.Close()
+	if panicked, msg := runExpectPanic(t, Config{LayerAPIURLs: []string{srv.URL}, GracePeriod: 80 * time.Millisecond, CheckInterval: queryInterval}); panicked {
+		t.Fatalf("expected resume (no panic) when disputes clear during grace: %q", msg)
+	}
+}
+
 func TestIsIgnored(t *testing.T) {
 	if !isIgnored([]uint64{1, 2, 3}, 2) {
 		t.Fatal("2 should be ignored")
@@ -165,6 +249,9 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("API_URLS", "http://a:1317, http://b:1317")
 	t.Setenv("DISPUTE_IGNORE_IDS", "5, 9")
 	t.Setenv("DISPUTE_CHECK_INTERVAL", "3s")
+	t.Setenv("DISPUTE_MIN_REPORTER_POWER", "1000")
+	t.Setenv("DISPUTE_TRIGGER_THRESHOLD", "2")
+	t.Setenv("DISPUTE_GRACE_PERIOD", "10m")
 	cfg := LoadConfigFromEnv([]string{"tcp://rpc:26657"})
 	if !cfg.Enabled {
 		t.Fatal("expected enabled")
@@ -180,5 +267,14 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	}
 	if len(cfg.RPCEndpoints) != 1 {
 		t.Fatalf("rpc: %v", cfg.RPCEndpoints)
+	}
+	if cfg.MinReporterPower != 1000 {
+		t.Fatalf("min power: %d", cfg.MinReporterPower)
+	}
+	if cfg.TriggerThreshold != 2 {
+		t.Fatalf("threshold: %d", cfg.TriggerThreshold)
+	}
+	if cfg.GracePeriod != 10*time.Minute {
+		t.Fatalf("grace: %v", cfg.GracePeriod)
 	}
 }


### PR DESCRIPTION
resolves #47.

The dispute guard currently halts reporting on the first open, non-ignored dispute. As raised in #47, this is exploitable: an adversary can stake 1 TRB, self-dispute, and halt the entire reporter network until every operator manually edits `DISPUTE_IGNORE_IDS` and restarts.
This adds three opt-in grief-prevention controls. **All defaults preserve the current strict behavior**, so existing deployments are unaffected until they opt in.

## Changes

* **Stake-weighted filtering**: `DISPUTE_MIN_REPORTER_POWER` (default `0`, disabled). Disputes against a report whose power is below the threshold are automatically ignored, preventing a tiny-stake self-dispute from triggering the guard. The disputed report's power is read from `/tellor-io/layer/dispute/dispute/{id}`. If that lookup fails, the dispute is still counted to fail safe and favor pausing.
* **Multi-dispute trigger threshold**: `DISPUTE_TRIGGER_THRESHOLD` (default `1`). Requires N concurrent qualifying disputes before pausing, so a single adversarial self-dispute, or an honest mistake, does not halt the network.
* **Configurable grace period / auto-resume**: `DISPUTE_GRACE_PERIOD` (default `0`, pause immediately). When the threshold is reached, the monitor waits for the configured duration and then re-evaluates. If the disputes have cleared (resolved or now ignorable), reporting resumes automatically without requiring a manual `DISPUTE_IGNORE_IDS` update or restart.
