### PR TITLE
fix regression to TRBBRidge (V1)

### DIFF
--- a/reporter/client/reporter_monitors.go
+++ b/reporter/client/reporter_monitors.go
@@ -401,11 +401,11 @@ func (c *Client) MonitorForTippedQueries(ctx context.Context, wg *sync.WaitGroup
 				haveCommited := commitedIds[query.Id]
 				mutex.Unlock()
 				if height > query.Expiration || haveCommited ||
-					!strings.EqualFold(queryType, "SpotPrice") && !strings.EqualFold(queryType, "TRBBridge") {
+					!strings.EqualFold(queryType, "SpotPrice") && !strings.EqualFold(queryType, "TRBBridgeV2") {
 					continue
 				}
 
-				if strings.EqualFold(queryType, "TRBBridge") {
+				if strings.EqualFold(queryType, "TRBBridgeV2") {
 					mutex.Lock()
 					haveCommitedTip := depositTipMap[query.Id]
 					mutex.Unlock()


### PR DESCRIPTION
One of the PRs we merged in must have accidentally changed the bridge query in reporter_monitors.go back to TRBBridge, which should not be TRBBridgeV2. This PR fixes this simple bug.